### PR TITLE
fix: Add enable_device_info_update flag to DeviceGatewayFetcher

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -16,6 +16,7 @@ device_fetcher:
   initial_backoff_max_seconds: ${oc.decode:${oc.env:DEVICE_FETCHER_INITIAL_BACKOFF_MAX_SECONDS, 60}}
   loop_interval_seconds: ${oc.decode:${oc.env:DEVICE_FETCHER_LOOP_INTERVAL_SECONDS, 60}}
   loop_backoff_max_seconds: ${oc.decode:${oc.env:DEVICE_FETCHER_LOOP_BACKOFF_MAX_SECONDS, 300}}
+  enable_device_info_update: ${oc.decode:${oc.env:DEVICE_FETCHER_ENABLE_DEVICE_INFO_UPDATE, true}}
 
 # repository configurations
 _job_repository:

--- a/core/config/sse_engine_config.yaml
+++ b/core/config/sse_engine_config.yaml
@@ -14,6 +14,7 @@ device_fetcher:
   initial_backoff_max_seconds: ${oc.decode:${oc.env:DEVICE_FETCHER_INITIAL_BACKOFF_MAX_SECONDS, 60}}
   loop_interval_seconds: ${oc.decode:${oc.env:DEVICE_FETCHER_LOOP_INTERVAL_SECONDS, 60}}
   loop_backoff_max_seconds: ${oc.decode:${oc.env:DEVICE_FETCHER_LOOP_BACKOFF_MAX_SECONDS, 300}}
+  enable_device_info_update: ${oc.decode:${oc.env:DEVICE_FETCHER_ENABLE_DEVICE_INFO_UPDATE, true}}
 
 # repository configurations
 job_repository:

--- a/core/src/oqtopus_engine_core/fetchers/device_gateway_fetcher.py
+++ b/core/src/oqtopus_engine_core/fetchers/device_gateway_fetcher.py
@@ -38,6 +38,7 @@ class DeviceGatewayFetcher(DeviceFetcher):
         initial_backoff_max_seconds: float = 60.0,
         loop_interval_seconds: float = 60.0,
         loop_backoff_max_seconds: float = 300.0,
+        enable_device_info_update: bool = True,  # noqa: FBT001, FBT002
     ) -> None:
         """Initialize the DeviceGatewayFetcher.
 
@@ -48,6 +49,7 @@ class DeviceGatewayFetcher(DeviceFetcher):
             initial_backoff_max_seconds: Maximum backoff time for initial fetch.
             loop_interval_seconds: Fetch interval in seconds after initialization.
             loop_backoff_max_seconds: Maximum backoff time for loop fetch in seconds.
+            enable_device_info_update: Whether to update device info from gateway.
 
         """
         super().__init__()
@@ -59,6 +61,7 @@ class DeviceGatewayFetcher(DeviceFetcher):
         self._initial_backoff_max_seconds = initial_backoff_max_seconds
         self._loop_interval_seconds = loop_interval_seconds
         self._loop_backoff_max_seconds = loop_backoff_max_seconds
+        self._enable_device_info_update = enable_device_info_update
 
         logger.info(
             "DeviceGatewayFetcher was initialized",
@@ -68,6 +71,7 @@ class DeviceGatewayFetcher(DeviceFetcher):
                 "initial_backoff_max_seconds": initial_backoff_max_seconds,
                 "loop_interval_seconds": loop_interval_seconds,
                 "loop_backoff_max_seconds": loop_backoff_max_seconds,
+                "enable_device_info_update": enable_device_info_update,
             },
         )
 
@@ -121,7 +125,8 @@ class DeviceGatewayFetcher(DeviceFetcher):
 
                 # update device info and status in cloud
                 await self.gctx.device_repository.update_device(device)
-                await self.gctx.device_repository.update_device_info(device)
+                if self._enable_device_info_update:
+                    await self.gctx.device_repository.update_device_info(device)
                 await self.gctx.device_repository.update_device_status(device)
                 break
 
@@ -204,7 +209,8 @@ class DeviceGatewayFetcher(DeviceFetcher):
                     self.gctx.device.device_info = curr_device_info
                     self.gctx.device.calibrated_at = curr_calibrated_at
                     # Update device repository
-                    await self.gctx.device_repository.update_device_info(device)
+                    if self._enable_device_info_update:
+                        await self.gctx.device_repository.update_device_info(device)
 
                 # Compare and update if status changed
                 prev_status = self.gctx.device.status


### PR DESCRIPTION
## ✍ Description
<!--- Describe your changes in detail -->

This PR adds a new boolean flag `enable_device_info_update` to the `DeviceGatewayFetcher`.

Some devices (e.g., simulators) do not support device calibration.
Sending a `PATCH /devices/{device_id}/device_info` request results in a permanent `400 Bad Request` response:

```
"Calibration is only supported for QPU devices"
```

To avoid unnecessary PATCH requests and meaningless retry loops, `update_device_info()` can now be conditionally disabled by setting `enable_device_info_update = False`.

**Default behavior remains unchanged (`True`).**