### PR TITLE
feat: Enable Arbitrary Ordering of Steps and Buffers in PipelineExecutor

### DIFF
--- a/core/src/oqtopus_engine_core/app.py
+++ b/core/src/oqtopus_engine_core/app.py
@@ -7,6 +7,7 @@ from oqtopus_engine_core.framework import (
     DeviceFetcher,
     GlobalContext,
     JobFetcher,
+    JobRepository,
     PipelineExceptionHandler,
     PipelineExecutor,
 )
@@ -40,20 +41,20 @@ async def main() -> None:
     )
 
     # Initialize the pipeline executor
+    job_buffer: Buffer = instantiate(gctx.config["buffer"])
     pipeline = PipelineExecutor(
-        before_buffer_steps=[
+        pipeline=[
             # instantiate(gctx.config["debug_step"]),  # noqa: ERA001
             instantiate(gctx.config["job_repository_update_step"]),
             instantiate(gctx.config["multi_manual_step"]),
             instantiate(gctx.config["tranqu_step"]),
             instantiate(gctx.config["estimator_step"]),
             instantiate(gctx.config["ro_error_mitigation_step"]),
-        ],
-        job_buffer=instantiate(gctx.config["buffer"]),
-        after_buffer_steps=[  # TODO after buffer step
+            job_buffer,
             instantiate(gctx.config["sse_step"]), #TODO: pipeline locked during sse step
             instantiate(gctx.config["device_gateway_step"]),
         ],
+        job_buffer=job_buffer,
         exception_handler=exception_handler,
     )
 
@@ -63,7 +64,8 @@ async def main() -> None:
     job_fetcher.pipeline = pipeline
 
     # Initialize the job repository
-    gctx.job_repository = instantiate(gctx.config["job_repository"])
+    job_repository: JobRepository = instantiate(gctx.config["job_repository"])
+    gctx.job_repository = job_repository
 
     # Initialize the device fetcher
     device_fetcher: DeviceFetcher = instantiate(gctx.config["device_fetcher"])

--- a/core/src/oqtopus_engine_core/framework/buffer.py
+++ b/core/src/oqtopus_engine_core/framework/buffer.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .context import GlobalContext, JobContext
     from .model import Job
 
 
-class Buffer(Protocol):
-    """Abstract interface for pipeline buffers.
+class Buffer(ABC):
+    """Abstract class for pipeline buffers.
 
     A Buffer stores `(gctx, jctx, job)` tuples and acts as an intermediate
     component between pipeline steps. Different Buffer implementations may
@@ -23,6 +24,7 @@ class Buffer(Protocol):
     along with a synchronous `size()` method for monitoring capacity.
     """
 
+    @abstractmethod
     async def put(self, gctx: GlobalContext, jctx: JobContext, job: Job) -> None:
         """Store a job tuple into the buffer.
 
@@ -32,8 +34,10 @@ class Buffer(Protocol):
             job: The raw job data.
 
         """
-        ...
+        message = "`put` must be implemented in subclasses of Buffer."
+        raise NotImplementedError(message)
 
+    @abstractmethod
     async def get(self) -> tuple[GlobalContext, JobContext, Job]:
         """Retrieve a stored job tuple from the buffer.
 
@@ -41,8 +45,10 @@ class Buffer(Protocol):
             A tuple `(gctx, jctx, job)` removed from the buffer.
 
         """
-        ...
+        message = "`get` must be implemented in subclasses of Buffer."
+        raise NotImplementedError(message)
 
+    @abstractmethod
     def size(self) -> int:
         """Return the number of items stored in the buffer.
 
@@ -50,4 +56,5 @@ class Buffer(Protocol):
             The number of queued elements.
 
         """
-        ...
+        message = "`size` must be implemented in subclasses of Buffer."
+        raise NotImplementedError(message)


### PR DESCRIPTION
## Summary

This PR refactors the PipelineExecutor to support arbitrary ordering of Steps and Buffers within the pipeline definition.
Previously, the pipeline assumed a fixed structure or positional constraints (e.g., buffer positions tightly coupled to step indexing).
With this change, Steps and Buffers can now be placed freely, enabling more expressive and flexible pipeline configurations.

## 🔧 Key Changes
1. Unified Linear Pipeline Model
  - The executor now accepts a single pipeline: list[Step | Buffer].
  - Any number of Steps and Buffers can appear in any order.
  - Execution begins at index 0 and progresses linearly.

2. Updated Forward/Backward Execution Logic
- Forward pass (PRE_PROCESS) proceeds step-by-step until:
  - A Buffer is encountered → the job is enqueued and execution pauses.
  - The end of the pipeline → a full backward pass is triggered.
- Backward pass (POST_PROCESS) iterates in reverse order, calling post_process() only on Step nodes.

3. Automatic Worker Spawning per Buffer
- A dedicated worker task is spawned for each Buffer in the pipeline.
- Workers resume execution immediately after their associated Buffer.

4. No Position Tracking Required in JobContext
- jctx.position or similar fields are no longer necessary.
- All traversal logic is handled internally by the executor.

5. Improved Robustness in Worker Loop
- Unexpected exceptions inside workers no longer terminate the worker task.
- Ensures stable long-running behavior without graceful shutdown.

## 🚀 Benefits
- Flexible pipeline construction: Steps and Buffers can be freely arranged.
- Extensible design: Future features such as Split/Join and Multi-Programming can be built on top of the model.
- Cleaner pipeline definitions: No need for explicit tracking of positions or phases.
- Better maintainability: Simplified and unified execution path for forward and backward phases.
- More robust runtime behavior: Worker loops recover from exceptions instead of silently dying.