### PR TITLE
feat: support detached pipeline execution (DetachOnPreprocess / DetachOnPostprocess)

### DIFF
--- a/core/src/oqtopus_engine_core/framework/__init__.py
+++ b/core/src/oqtopus_engine_core/framework/__init__.py
@@ -16,10 +16,20 @@ from .model import (
     TranspileResult,
 )
 from .pipeline import PipelineExecutor
-from .step import Step
+from .step import (
+    DetachOnPostprocess,
+    DetachOnPreprocess,
+    JoinOnPostprocess,
+    JoinOnPreprocess,
+    SplitOnPostprocess,
+    SplitOnPreprocess,
+    Step,
+)
 
 __all__ = [
     "Buffer",
+    "DetachOnPostprocess",
+    "DetachOnPreprocess",
     "Device",
     "DeviceFetcher",
     "DeviceRepository",
@@ -31,10 +41,14 @@ __all__ = [
     "JobInfo",
     "JobRepository",
     "JobResult",
+    "JoinOnPostprocess",
+    "JoinOnPreprocess",
     "OperatorItem",
     "PipelineExceptionHandler",
     "PipelineExecutor",
     "SamplingResult",
+    "SplitOnPostprocess",
+    "SplitOnPreprocess",
     "Step",
     "TranspileResult",
 ]

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -11,6 +11,7 @@ from oqtopus_engine_core.framework import (
     SamplingResult,
     Step,
 )
+from oqtopus_engine_core.framework.step import DetachOnPostprocess
 from oqtopus_engine_core.interfaces.qpu_interface.v1 import qpu_pb2, qpu_pb2_grpc
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ def _select_program(job: Job) -> str:
     return transpile_result.transpiled_program
 
 
-class DeviceGatewayStep(Step):
+class DeviceGatewayStep(Step, DetachOnPostprocess):
     """Step that sends a job to the device gateway via gRPC during pre_process."""
 
     def __init__(self, gateway_address: str = "localhost:50051") -> None:
@@ -66,7 +67,7 @@ class DeviceGatewayStep(Step):
 
         # Update job status
         job.status = "running"
-        # TODO nowait
+        # TODO: nowait
         # await gctx.job_repository.update_job_status_nowait(job)
         await gctx.job_repository.update_job_status(job)
 

--- a/core/tests/oqtopus_engine_core/framework/test_steps.py
+++ b/core/tests/oqtopus_engine_core/framework/test_steps.py
@@ -1,49 +1,61 @@
 import pytest
 
-from oqtopus_engine_core.framework.step import (
-    SplitOnPreprocess,
-    SplitOnPostprocess,
-    JoinOnPreprocess,
+from oqtopus_engine_core.framework import (
+    DetachOnPostprocess,
+    DetachOnPreprocess,
     JoinOnPostprocess,
+    JoinOnPreprocess,
+    SplitOnPostprocess,
+    SplitOnPreprocess,
 )
-
 
 # ================================================================
 # Valid combinations (must NOT raise TypeError)
 # ================================================================
 
+
 def test_valid_inherit_split_preprocess():
     """A class inheriting SplitOnPreprocess alone is valid."""
+
     class MyStep(SplitOnPreprocess):
         pass
+
     assert True  # No exception means success
 
 
 def test_valid_inherit_split_postprocess():
     """A class inheriting SplitOnPostprocess alone is valid."""
+
     class MyStep(SplitOnPostprocess):
         pass
+
     assert True
 
 
 def test_valid_inherit_join_preprocess():
     """A class inheriting JoinOnPreprocess alone is valid."""
+
     class MyStep(JoinOnPreprocess):
         pass
+
     assert True
 
 
 def test_valid_inherit_join_postprocess():
     """A class inheriting JoinOnPostprocess alone is valid."""
+
     class MyStep(JoinOnPostprocess):
         pass
+
     assert True
 
 
 def test_valid_inherit_no_mixins():
     """A class with no mixins should be valid."""
+
     class MyStep:
         pass
+
     assert True
 
 
@@ -52,8 +64,10 @@ def test_valid_cross_phase_mixins_split_join():
     SplitOnPreprocess + JoinOnPostprocess is allowed,
     because they belong to different process phases.
     """
+
     class MyStep(SplitOnPreprocess, JoinOnPostprocess):
         pass
+
     assert True
 
 
@@ -62,8 +76,52 @@ def test_valid_cross_phase_mixins_join_split():
     JoinOnPreprocess + SplitOnPostprocess is allowed,
     because they belong to different process phases.
     """
+
     class MyStep(JoinOnPreprocess, SplitOnPostprocess):
         pass
+
+    assert True
+
+
+def test_valid_inherit_detach_preprocess():
+    """A class inheriting DetachOnPreprocess alone is valid."""
+
+    class MyStep(DetachOnPreprocess):
+        pass
+
+    assert True
+
+
+def test_valid_inherit_detach_postprocess():
+    """A class inheriting DetachOnPostprocess alone is valid."""
+
+    class MyStep(DetachOnPostprocess):
+        pass
+
+    assert True
+
+
+def test_valid_cross_phase_detach_and_split():
+    """
+    DetachOnPreprocess + SplitOnPostprocess is allowed because they belong
+    to different phases.
+    """
+
+    class MyStep(DetachOnPreprocess, SplitOnPostprocess):
+        pass
+
+    assert True
+
+
+def test_valid_cross_phase_detach_and_join():
+    """
+    DetachOnPostprocess + JoinOnPreprocess is allowed because they belong
+    to different phases.
+    """
+
+    class MyStep(JoinOnPreprocess, DetachOnPostprocess):
+        pass
+
     assert True
 
 
@@ -71,12 +129,14 @@ def test_valid_cross_phase_mixins_join_split():
 # Invalid combinations (must raise TypeError)
 # ================================================================
 
+
 def test_invalid_split_and_join_preprocess():
     """
     SplitOnPreprocess and JoinOnPreprocess are mutually exclusive.
     Defining a class with both must raise TypeError.
     """
     with pytest.raises(TypeError):
+
         class BadStep(SplitOnPreprocess, JoinOnPreprocess):
             pass
 
@@ -87,6 +147,7 @@ def test_invalid_split_and_join_postprocess():
     Defining a class with both must raise TypeError.
     """
     with pytest.raises(TypeError):
+
         class BadStep(SplitOnPostprocess, JoinOnPostprocess):
             pass
 
@@ -97,6 +158,7 @@ def test_invalid_order_reverse_preprocess():
     (JoinOnPreprocess + SplitOnPreprocess)
     """
     with pytest.raises(TypeError):
+
         class BadStep(JoinOnPreprocess, SplitOnPreprocess):
             pass
 
@@ -107,5 +169,68 @@ def test_invalid_order_reverse_postprocess():
     (JoinOnPostprocess + SplitOnPostprocess)
     """
     with pytest.raises(TypeError):
+
         class BadStep(JoinOnPostprocess, SplitOnPostprocess):
+            pass
+
+
+def test_invalid_split_and_detach_preprocess():
+    """
+    SplitOnPreprocess and DetachOnPreprocess are mutually exclusive.
+    """
+    with pytest.raises(TypeError):
+
+        class BadStep(SplitOnPreprocess, DetachOnPreprocess):
+            pass
+
+
+def test_invalid_join_and_detach_preprocess():
+    """
+    JoinOnPreprocess and DetachOnPreprocess are mutually exclusive.
+    """
+    with pytest.raises(TypeError):
+
+        class BadStep(JoinOnPreprocess, DetachOnPreprocess):
+            pass
+
+
+def test_invalid_detach_preprocess_reverse_order():
+    """
+    Reverse inheritance order must also raise TypeError.
+    (DetachOnPreprocess + SplitOnPreprocess)
+    """
+    with pytest.raises(TypeError):
+
+        class BadStep(DetachOnPreprocess, SplitOnPreprocess):
+            pass
+
+
+def test_invalid_split_and_detach_postprocess():
+    """
+    SplitOnPostprocess and DetachOnPostprocess are mutually exclusive.
+    """
+    with pytest.raises(TypeError):
+
+        class BadStep(SplitOnPostprocess, DetachOnPostprocess):
+            pass
+
+
+def test_invalid_join_and_detach_postprocess():
+    """
+    JoinOnPostprocess and DetachOnPostprocess are mutually exclusive.
+    """
+    with pytest.raises(TypeError):
+
+        class BadStep(JoinOnPostprocess, DetachOnPostprocess):
+            pass
+
+
+def test_invalid_detach_postprocess_reverse_order():
+    """
+    Reverse inheritance order must also raise TypeError.
+    (DetachOnPostprocess + SplitOnPostprocess)
+    """
+    with pytest.raises(TypeError):
+
+        class BadStep(DetachOnPostprocess, SplitOnPostprocess):
             pass

--- a/docs/developer_guidelines/implementing_pipeline.md
+++ b/docs/developer_guidelines/implementing_pipeline.md
@@ -172,11 +172,26 @@ class MyJoinStep(Step, JoinOnPostprocess):
 
 ### 5.1 Valid and Invalid Combinations
 
-- A step must not implement both split and join behavior at the same time.  
-  The following class-level combinations are therefore prohibited:
+For each phase (pre-process / post-process), a step may have **at most one**
+control-flow mixin.
 
-  - A step cannot derive from both `SplitOnPreprocess` and `JoinOnPreprocess`.
-  - A step cannot derive from both `SplitOnPostprocess` and `JoinOnPostprocess`.
+Invalid (TypeError):
+
+- Multiple *pre-process* mixins:
+  - `SplitOnPreprocess`
+  - `JoinOnPreprocess`
+  - `DetachOnPreprocess`
+
+- Multiple *post-process* mixins:
+  - `SplitOnPostprocess`
+  - `JoinOnPostprocess`
+  - `DetachOnPostprocess`
+
+Valid:
+
+- Any combination where mixins belong to **different phases**  
+  (e.g., `JoinOnPreprocess` + `DetachOnPostprocess`)
+- Steps without any control-flow mixin
 
 If a step violates these constraints, the engine will raise a `TypeError` during class construction.
 


### PR DESCRIPTION
## ✍ Description
<!--- Describe your changes in detail -->

Support detached pipeline execution

This pull request introduces support for detached pipeline execution in the OQTOPUS Engine. It adds two new step mixins, `DetachOnPreprocess` and `DetachOnPostprocess`, which allow part of a pipeline to continue in a separate background coroutine while the worker returns to the buffer loop.
