### PR TITLE
feat: add max_concurrency property to Buffer and update QueueBuffer

### DIFF
--- a/core/src/oqtopus_engine_core/buffers/queue_buffer.py
+++ b/core/src/oqtopus_engine_core/buffers/queue_buffer.py
@@ -19,11 +19,14 @@ class QueueBuffer(Buffer):
     Args:
         maxsize: Maximum number of elements allowed in the queue.
             A value of 0 indicates unlimited capacity.
+        max_concurrency: Maximum number of worker tasks allowed to consume
+            from this buffer concurrently. Defaults to 1.
 
     """
 
-    def __init__(self, maxsize: int = 0) -> None:
+    def __init__(self, maxsize: int = 0, max_concurrency: int = 1) -> None:
         self._queue: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
+        self._max_concurrency = max_concurrency
 
     async def put(self, gctx: GlobalContext, jctx: JobContext, job: Job) -> None:
         """Insert a tuple into the buffer.
@@ -59,3 +62,8 @@ class QueueBuffer(Buffer):
 
         """
         return self._queue.qsize()
+
+    @property
+    def max_concurrency(self) -> int:
+        """Return the maximum worker concurrency for this buffer."""
+        return self._max_concurrency

--- a/core/src/oqtopus_engine_core/framework/buffer.py
+++ b/core/src/oqtopus_engine_core/framework/buffer.py
@@ -58,3 +58,17 @@ class Buffer(ABC):
         """
         message = "`size` must be implemented in subclasses of Buffer."
         raise NotImplementedError(message)
+
+    @property
+    def max_concurrency(self) -> int:
+        """Return the maximum number of worker tasks.
+
+        This value specifies how many concurrent workers may consume items
+        from the buffer. Subclasses may override this to implement custom
+        concurrency settings.
+
+        Returns:
+            The maximum number of concurrent worker tasks. Defaults to 1.
+
+        """
+        return 1

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -87,8 +87,10 @@ class PipelineExecutor:
         """Start pipeline workers and enter a long-running idle loop."""
         for index, node in enumerate(self._pipeline):
             if isinstance(node, Buffer):
-                task = asyncio.create_task(self._worker_loop(node, index))
-                self._workers.append(task)
+                # Spawn one worker per allowed concurrency level.
+                for _ in range(node.max_concurrency):
+                    task = asyncio.create_task(self._worker_loop(node, index))
+                    self._workers.append(task)
 
         # Block forever until stop() is called
         await self._stop_event.wait()

--- a/core/tests/oqtopus_engine_core/buffers/test_queue_buffer.py
+++ b/core/tests/oqtopus_engine_core/buffers/test_queue_buffer.py
@@ -1,0 +1,106 @@
+import asyncio
+import pytest
+
+from oqtopus_engine_core.buffers.queue_buffer import QueueBuffer
+from oqtopus_engine_core.framework.context import GlobalContext, JobContext
+from oqtopus_engine_core.framework.model import JobInfo, Job
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def make_buffer_test_job(job_id: str) -> Job:
+    """Minimal job instance used only for QueueBuffer unit tests."""
+    return Job(
+        job_id=job_id,
+        job_type="test",
+        device_id="test-device",
+        shots=1,
+        job_info=JobInfo(program=[]),
+        transpiler_info={},
+        simulator_info={},
+        mitigation_info={},
+        status="CREATED",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic behavior
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_queue_buffer_put_and_get_returns_items_in_order():
+    """QueueBuffer should behave as FIFO."""
+    buffer = QueueBuffer()
+
+    g1, j1, job1 = GlobalContext(config={}), JobContext(initial={}), make_buffer_test_job("1")
+    g2, j2, job2 = GlobalContext(config={}), JobContext(initial={}), make_buffer_test_job("2")
+
+    await buffer.put(g1, j1, job1)
+    await buffer.put(g2, j2, job2)
+
+    # First in → first out
+    out1 = await buffer.get()
+    out2 = await buffer.get()
+
+    assert out1 == (g1, j1, job1)
+    assert out2 == (g2, j2, job2)
+
+
+@pytest.mark.asyncio
+async def test_queue_buffer_size_updates_correctly():
+    """size() must reflect the number of elements currently in the queue."""
+    buffer = QueueBuffer()
+
+    assert buffer.size() == 0
+
+    g, j, job = GlobalContext(config={}), JobContext(initial={}), make_buffer_test_job("x")
+    await buffer.put(g, j, job)
+    assert buffer.size() == 1
+
+    await buffer.get()
+    assert buffer.size() == 0
+
+
+# ---------------------------------------------------------------------------
+# max_concurrency property
+# ---------------------------------------------------------------------------
+
+def test_queue_buffer_default_max_concurrency_is_one():
+    """Default max_concurrency should be 1."""
+    buffer = QueueBuffer()
+    assert buffer.max_concurrency == 1
+
+
+def test_queue_buffer_custom_max_concurrency_is_retained():
+    """Custom max_concurrency should be stored and returned correctly."""
+    buffer = QueueBuffer(max_concurrency=4)
+    assert buffer.max_concurrency == 4
+
+
+# ---------------------------------------------------------------------------
+# Capacity control (optional behavior)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_queue_buffer_respects_maxsize():
+    """If maxsize > 0, put() should block when queue is full."""
+    buffer = QueueBuffer(maxsize=1)
+
+    g1, j1, job1 = GlobalContext(config={}), JobContext(initial={}), make_buffer_test_job("1")
+    g2, j2, job2 = GlobalContext(config={}), JobContext(initial={}), make_buffer_test_job("2")
+
+    await buffer.put(g1, j1, job1)
+
+    # This task will block because queue is full (maxsize=1)
+    put_task = asyncio.create_task(buffer.put(g2, j2, job2))
+
+    await asyncio.sleep(0.1)
+    assert not put_task.done()  # not completed yet
+
+    # Once we get one item, the second put() can proceed
+    await buffer.get()
+    await asyncio.sleep(0.1)
+
+    assert put_task.done()

--- a/core/tests/oqtopus_engine_core/framework/test_buffer.py
+++ b/core/tests/oqtopus_engine_core/framework/test_buffer.py
@@ -1,0 +1,94 @@
+import pytest
+
+from oqtopus_engine_core.framework.buffer import Buffer
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+class GlobalContext:
+    pass
+
+
+class JobContext:
+    pass
+
+
+class Job:
+    pass
+
+
+class DummyBuffer(Buffer):
+    """Simple in-memory buffer for testing Buffer's abstract interface."""
+
+    def __init__(self, max_concurrency: int = 1):
+        self._items = []
+        self._max_concurrency = max_concurrency
+
+    async def put(self, gctx: GlobalContext, jctx: JobContext, job: Job):
+        # Store a tuple exactly as the Buffer contract specifies.
+        self._items.append((gctx, jctx, job))
+
+    async def get(self):
+        # Retrieve FIFO for simplicity.
+        return self._items.pop(0)
+
+    def size(self) -> int:
+        return len(self._items)
+
+    def max_concurrency(self) -> int:
+        return self._max_concurrency
+
+# ---------------------------------------------------------------------------
+# Test Cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_buffer_put_get_and_size():
+    """
+    Ensure that put() stores items correctly, size() reflects the number of
+    stored items, and get() returns them in the expected order.
+    """
+    buf = DummyBuffer()
+
+    g1, j1, job1 = GlobalContext(), JobContext(), Job()
+    g2, j2, job2 = GlobalContext(), JobContext(), Job()
+
+    await buf.put(g1, j1, job1)
+    await buf.put(g2, j2, job2)
+
+    assert buf.size() == 2
+
+    out1 = await buf.get()
+    assert out1 == (g1, j1, job1)
+    assert buf.size() == 1
+
+    out2 = await buf.get()
+    assert out2 == (g2, j2, job2)
+    assert buf.size() == 0
+
+
+def test_buffer_default_max_concurrency():
+    """
+    Default max_concurrency() in the base class should return 1.
+    """
+    class DefaultBuffer(Buffer):
+        async def put(self, gctx: GlobalContext, jctx: JobContext, job: Job):
+            pass
+
+        async def get(self):
+            return None
+
+        def size(self) -> int:
+            return 0
+
+    buf = DefaultBuffer()
+    assert buf.max_concurrency == 1
+
+
+def test_buffer_overridden_max_concurrency():
+    """
+    Custom Buffer implementations may override max_concurrency().
+    """
+    buf = DummyBuffer(max_concurrency=4)
+    assert buf.max_concurrency() == 4


### PR DESCRIPTION
## ✍ Description

This PR introduces configurable worker concurrency for buffers.

- Adds `max_concurrency` as a property to the `Buffer` interface.
- Updates `QueueBuffer` to accept `max_concurrency` via constructor.
- PipelineExecutor now spawns `buffer.max_concurrency` workers per buffer.
- Updates the documentation (Section 5) to describe the new behavior and provide an example `config.yaml` for QueueBuffer.

## Rationale

Buffer-level worker concurrency allows more flexible and scalable pre-process execution, especially in pipelines where certain segments benefit from increased parallel consumption.

## Notes

- The detailed behavior, sequencing, and config examples are described in the updated documentation.
- Default concurrency is `1`, ensuring backward compatibility.