### PR TITLE
docs: Add documentation example for configuring max_concurrency

### DIFF
--- a/docs/design/pipeline_execution.md
+++ b/docs/design/pipeline_execution.md
@@ -199,10 +199,9 @@ pipeline_executor:
 di_container:
   registry:
     buffer:
-      class: oqtopus_engine_core.buffers.QueueBuffer
-      kwargs:
-        maxsize: 0           # optional, unlimited queue
-        max_concurrency: 3   # spawn 3 workers for this buffer
+      _target_: oqtopus_engine_core.buffers.QueueBuffer
+      maxsize: 0           # optional, unlimited queue
+      max_concurrency: 3   # spawn 3 workers for this buffer
 ```
 
 ## 6. Split Execution


### PR DESCRIPTION
## ✍ Description

Add documentation example for configuring max_concurrency.

```yaml
di_container:
  registry:
    buffer:
      _target_: oqtopus_engine_core.buffers.QueueBuffer
      maxsize: 0           # optional, unlimited queue
      max_concurrency: 3   # spawn 3 workers for this buffer
```