### PR TITLE
fix: Add Double-Checked Locking to DIContainer.get for Thread-Safe Singleton Instantiation

### DIFF
--- a/core/src/oqtopus_engine_core/utils/di_container.py
+++ b/core/src/oqtopus_engine_core/utils/di_container.py
@@ -1,4 +1,5 @@
 import importlib
+import threading
 from typing import Any
 
 
@@ -40,7 +41,10 @@ class DiContainer:
 
         """
         self._config = config
-        self._instances: dict[str, Any] = {}  # cache for singletons
+        # Initialize a lock for thread-safe instance creation
+        self._lock = threading.Lock()
+        # cache for singletons
+        self._singleton_instances: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -73,18 +77,28 @@ class DiContainer:
             message = f"Unknown dependency: {name}"
             raise KeyError(message)
 
-        # Singleton cache check
-        if name in self._instances:
-            return self._instances[name]
+        # First check (no lock)
+        instance = self._singleton_instances.get(name)
+        if instance is not None:
+            return instance
 
-        instance = self._create_instance(name)
-
-        # Cache only if singleton
         scope = self._config[name].get("_scope_", "singleton")
-        if scope == "singleton":
-            self._instances[name] = instance
 
-        return instance
+        # If prototype, no locking needed for cache
+        if scope == "prototype":
+            return self._create_instance(name)
+
+        # Double-Checked Locking section
+        with self._lock:
+            # Second check (after acquiring lock)
+            instance = self._singleton_instances.get(name)
+            if instance is not None:
+                return instance
+
+            # Create and cache
+            instance = self._create_instance(name)
+            self._singleton_instances[name] = instance
+            return instance
 
     # ------------------------------------------------------------------
     # Internal helpers


### PR DESCRIPTION
# ✍ Description

## Summary

This PR introduces **double-checked locking (DCL)** to `DIContainer.get()` to ensure
thread-safe singleton instantiation while keeping the fast path lightweight.

The change improves safety in multi-threaded environments where multiple workers
may attempt to retrieve the same dependency concurrently.

## Key Changes
- Added `threading.Lock()` to `DIContainer` for controlling singleton creation.
- Implemented **double-checked locking** pattern:
  - First check without lock (fast path).
  - Second check inside the lock (safe path).
- Singleton instances are now fully protected from race conditions.
- Prototype-scoped components remain lock-free and unaffected.

## Motivation
Without DCL, two threads may attempt to construct the same singleton
simultaneously, causing redundant instantiations or inconsistent internal state.
DCL ensures correctness with minimal performance overhead.