### PR TITLE
fix: unit test failures of multi-programming

### DIFF
--- a/core/tests/oqtopus_engine_core/steps/test_multi_manual_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_multi_manual_step.py
@@ -33,7 +33,7 @@ def test_divide_string_by_lengths(input_str, lengths, expected, error):
 
 
 @pytest.mark.parametrize(
-    "counts, vpm_raw, combined_qubits_list, expected_counts, expected_divided, error",
+    "counts, combined_qubits_list, expected_counts, expected_divided, error",
     [
         # 1 circuit
         (
@@ -46,7 +46,6 @@ def test_divide_string_by_lengths(input_str, lengths, expected, error):
                 "0110": 32,
                 "1011": 64,
             },
-            {"qubit_mapping": {0: 0, 1: 1, 2: 2, 3: 3}},
             [4],
             {
                 "0001": 1,
@@ -81,7 +80,6 @@ def test_divide_string_by_lengths(input_str, lengths, expected, error):
                 "0110": 32,
                 "1011": 64,
             },
-            {"qubit_mapping": {0: 0, 1: 1, 2: 2, 3: 3}},
             [3, 1],
             {
                 "0001": 1,
@@ -107,11 +105,11 @@ def test_divide_string_by_lengths(input_str, lengths, expected, error):
             None,
         ),
         # Negative test - no qubit
-        ({}, {"qubit_mapping": {}}, [], {}, None, "inconsistent qubit property"),
+        ({}, [], {}, None, "inconsistent qubit property"),
     ],
 )
 def test_divide_result(
-    counts, vpm_raw, combined_qubits_list, expected_counts, expected_divided, error
+    counts, combined_qubits_list, expected_counts, expected_divided, error
 ):
     job_result = JobResult(
         sampling={
@@ -141,14 +139,13 @@ def test_divide_result(
         },
     )
     jctx = {"combined_qubits_list": combined_qubits_list}
-    # Convert vpm_raw to a proper virtual physical mapping
     if error:
         with pytest.raises(ValueError) as e:
-            divide_result(job=job, jctx=jctx, virtual_physical_mapping=vpm_raw)
+            divide_result(job=job, jctx=jctx)
         assert error in str(e.value)
     else:
         divided_counts = divide_result(
-            job=job, jctx=jctx, virtual_physical_mapping=vpm_raw
+            job=job, jctx=jctx
         )
         assert job.job_info.result.sampling.counts == expected_counts
         assert divided_counts == expected_divided


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
Fix the unit test failures of multi-programming manual.
Virtual physical mapping is no longer in use.

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
