### PR TITLE
test(core): align estimator/mitigation step tests with gRPC flow

### DIFF
--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -1,264 +1,147 @@
-import cmath
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
-from qiskit import qasm3
-from qiskit.primitives import BackendEstimatorV2, StatevectorSampler
-from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.quantum_info.operators import SparsePauliOp
-from qiskit.quantum_info.operators.random import random_hermitian
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit_aer.backends import AerSimulator
 
 from oqtopus_engine_core.framework.model import OperatorItem
-from oqtopus_engine_core.steps import EstimatorStep
+from oqtopus_engine_core.steps.estimator_step import EstimationJobInfo, EstimatorStep
 
 
 @pytest.fixture
-def estimator_step_instance():
-    return EstimatorStep()
+def estimator_step_instance() -> EstimatorStep:
+    step = EstimatorStep(basis_gates=["cx", "rz", "sx", "measure"])
+    step._stub = MagicMock()
+    step._stub.ReqEstimationPreProcess = AsyncMock()
+    step._stub.ReqEstimationPostProcess = AsyncMock()
+    return step
 
 
-def test_create_qiskit_operator(
+@pytest.mark.asyncio
+async def test_pre_process_calls_grpc_and_updates_jctx(
     estimator_step_instance: EstimatorStep,
-):
-    operators = [
-        OperatorItem(pauli="X 0 X 1", coeff=1.5),
-        OperatorItem(pauli="Y 0 Z 1", coeff=1.2),
-    ]
-    pauli_op = estimator_step_instance.create_qiskit_operator(operators, 2)
-    assert pauli_op.to_list()[0] == ("XX", complex(1.5, 0.0))
-    assert pauli_op.to_list()[1] == ("ZY", complex(1.2, 0.0))
+) -> None:
+    gctx = MagicMock()
+    jctx: dict[str, object] = {}
+    job = MagicMock()
+    job.job_id = "job-1"
+    job.job_type = "estimation"
+    job.job_info.transpile_result = None
+    job.job_info.program = ["OPENQASM 3.0;\n"]
+    job.job_info.operator = [OperatorItem(pauli="X 0", coeff=1.0)]
 
-    operators = [
-        OperatorItem(pauli="X0 X1", coeff=1.5),
-        OperatorItem(pauli="Y0 Z1", coeff=1.2),
-    ]
-    pauli_op = estimator_step_instance.create_qiskit_operator(operators, 3)
-    assert pauli_op.to_list()[0] == ("IXX", complex(1.5, 0.0))
-    assert pauli_op.to_list()[1] == ("IZY", complex(1.2, 0.0))
-
-    operators = [
-        OperatorItem(pauli="I", coeff=2.0),
-    ]
-    pauli_op = estimator_step_instance.create_qiskit_operator(
-        operators=operators, n_qubits=5
+    estimator_step_instance._stub.ReqEstimationPreProcess.return_value = SimpleNamespace(
+        qasm_codes=["preprocessed-qasm"],
+        grouped_operators=json.dumps([[ ["X"] ], [ [1.0] ]]),
     )
-    assert pauli_op.to_list()[0] == ("IIIII", complex(2.0, 0.0))
+
+    await estimator_step_instance.pre_process(gctx, jctx, job)
+
+    assert "estimation_job_info" in jctx
+    info = jctx["estimation_job_info"]
+    assert isinstance(info, EstimationJobInfo)
+    assert info.preprocessed_qasms == ["preprocessed-qasm"]
+    assert info.grouped_operators == [[["X"]], [[1.0]]]
+
+    estimator_step_instance._stub.ReqEstimationPreProcess.assert_awaited_once()
+    request = estimator_step_instance._stub.ReqEstimationPreProcess.call_args.args[0]
+    assert request.qasm_code == "OPENQASM 3.0;\n"
+    assert request.operators == "[('X 0', 1.0)]"
+    assert list(request.basis_gates) == ["cx", "rz", "sx", "measure"]
+    assert list(request.mapping_list) == []
 
 
-def test__pre_process(
+@pytest.mark.asyncio
+async def test_pre_process_uses_transpile_mapping_in_sorted_order(
     estimator_step_instance: EstimatorStep,
-):
-    # Prepare a simple QASM and operator
-    qasm_code = """
-    OPENQASM 3;
-    include "stdgates.inc";
-    qubit[2] q;
-    x q[0];
-    """
-    input_operators = [OperatorItem(pauli="X 0", coeff=1.0)]
-    virtual_physical_mapping = {"0": 1, "1": 0}
-    basis_gates = ["cx", "id", "rz", "sx", "x", "reset", "delay", "measure"]
-    actual_preprocessed_qasms, actual_grouped_operators = (
-        estimator_step_instance._pre_process(
-            qasm_code=qasm_code,
-            operators=input_operators,
-            virtual_physical_mapping=virtual_physical_mapping,
-            basis_gates=basis_gates,
+) -> None:
+    gctx = MagicMock()
+    jctx: dict[str, object] = {}
+    job = MagicMock()
+    job.job_id = "job-2"
+    job.job_type = "estimation"
+    job.job_info.program = ["unused"]
+    job.job_info.operator = [OperatorItem(pauli="Z 1", coeff=2.0)]
+    job.job_info.transpile_result = SimpleNamespace(
+        transpiled_program="TRANSPILED",
+        virtual_physical_mapping={"qubit_mapping": {"1": 0, "0": 2}},
+    )
+
+    estimator_step_instance._stub.ReqEstimationPreProcess.return_value = SimpleNamespace(
+        qasm_codes=["qasm"],
+        grouped_operators=json.dumps([[ ["Z"] ], [ [2.0] ]]),
+    )
+
+    await estimator_step_instance.pre_process(gctx, jctx, job)
+
+    request = estimator_step_instance._stub.ReqEstimationPreProcess.call_args.args[0]
+    assert request.qasm_code == "TRANSPILED"
+    assert list(request.mapping_list) == [2, 0]
+
+
+@pytest.mark.asyncio
+async def test_pre_process_raises_when_operator_missing(
+    estimator_step_instance: EstimatorStep,
+) -> None:
+    gctx = MagicMock()
+    jctx: dict[str, object] = {}
+    job = MagicMock()
+    job.job_id = "job-3"
+    job.job_type = "estimation"
+    job.job_info.transpile_result = None
+    job.job_info.program = ["OPENQASM 3.0;\n"]
+    job.job_info.operator = None
+
+    with pytest.raises(ValueError, match="operator is not specified"):
+        await estimator_step_instance.pre_process(gctx, jctx, job)
+
+
+@pytest.mark.asyncio
+async def test_post_process_calls_grpc_and_updates_job_result(
+    estimator_step_instance: EstimatorStep,
+) -> None:
+    gctx = MagicMock()
+    job = MagicMock()
+    job.job_id = "job-4"
+    job.job_type = "estimation"
+    job.job_info.result = None
+
+    jctx = {
+        "estimation_job_info": SimpleNamespace(
+            counts_list=[{"00": 10, "11": 20}],
+            grouped_operators=[[["ZZ"]], [[1.0]]],
         )
-    )
-    expected_qasm = 'OPENQASM 3.0;\ninclude "stdgates.inc";\nbit[1] __c_XI;\nqubit[2] q;\nx q[0];\nrz(pi/2) q[1];\nsx q[1];\nrz(pi/2) q[1];\n__c_XI[0] = measure q[1];\n'
-    expected_operator = [[["X"]], [[1.0]]]
-    assert actual_preprocessed_qasms[0] == expected_qasm
-    assert actual_grouped_operators == expected_operator
-
-
-def test__post_process(
-    estimator_step_instance: EstimatorStep,
-):
-    counts_list: list[dict[str, int]] = [
-        {"0000": 500, "0100": 0, "1000": 0, "1100": 500},
-        {"0000": 250, "0100": 250, "1000": 250, "1100": 250},
-    ]
-    input_operator = [[["XXII"], ["YZII"]], [[1.5], [1.2]]]
-    actual_expval, actual_stds = estimator_step_instance._post_process(
-        counts_list, input_operator
-    )
-
-    # Check that the result was set correctly
-    expect_expval = np.float64(1.5)
-    expect_stds = np.float64(0.0)
-    assert cmath.isclose(actual_expval, expect_expval, abs_tol=1e-1)
-    assert cmath.isclose(actual_stds, expect_stds, abs_tol=1e-1)
-
-
-def test_simple_circuits_with_random_op(
-    estimator_step_instance: EstimatorStep,
-):
-    """Test estimation step with a simple circuit and a random operator."""
-    num_qubits = 2
-    basis_gates = ["cx", "id", "rz", "sx", "x", "reset", "delay", "measure"]
-
-    # Prepare a simple QASM and operator
-    qasm_code = (
-        'OPENQASM 3.0;\ninclude "stdgates.inc";\nqubit[2] q;\nh q[0];\ncx q[0], q[1];\n'
-    )
-    op = random_hermitian(dims=2**num_qubits, seed=1)
-    observable = SparsePauliOp.from_operator(op)
-    operators = [
-        OperatorItem(pauli=body[0], coeff=body[1])
-        for body in translate_operator2string(observable)
-    ]
-    # observable = SparsePauliOp.from_list([("XX", 1.5), ("ZY", 1.2)])
-    # operators = [
-    #     OperatorItem(pauli="X 0 X 1", coeff=1.5),
-    #     OperatorItem(pauli="Y 0 Z 1", coeff=1.2),
-    # ]
-    # transpile
-    backend = GenericBackendV2(num_qubits=10, basis_gates=basis_gates)
-    pm = generate_preset_pass_manager(optimization_level=2, backend=backend)
-    transpiled_qc = pm.run(qasm3.loads(qasm_code))
-    layout = transpiled_qc.layout
-    mapping_list = layout.final_index_layout(filter_ancillas=True)
-    virtual_physical_mapping = {
-        str(i): mapping_list[i] for i in range(len(mapping_list))
     }
 
-    # preprocess
-    preprocessed_qasms, grouped_paulis = estimator_step_instance._pre_process(
-        qasm_code=qasm3.dumps(transpiled_qc),
-        operators=operators,
-        basis_gates=basis_gates,
-        virtual_physical_mapping=virtual_physical_mapping,
+    estimator_step_instance._stub.ReqEstimationPostProcess.return_value = SimpleNamespace(
+        expval=0.25,
+        stds=0.05,
     )
 
-    # process
-    preprocessed_qc = [
-        qasm3.loads(preprocessed_qasm) for preprocessed_qasm in preprocessed_qasms
-    ]
-    sampler_qiskit = StatevectorSampler()
-    l_counts = []
-    for i, qc in enumerate(preprocessed_qc):
-        pubs = [(qc)]
-        job_qiskit = sampler_qiskit.run(pubs, shots=4096)
-        sampler_result = job_qiskit.result()
-        l_counts_test = sampler_result[0].data[qc.cregs[0].name].get_counts()
-        l_counts.append(l_counts_test)
+    await estimator_step_instance.post_process(gctx, jctx, job)
 
-    # postprocess
-    actual_expval, actual_stds = estimator_step_instance._post_process(
-        l_counts, grouped_paulis
-    )
+    estimator_step_instance._stub.ReqEstimationPostProcess.assert_awaited_once()
+    request = estimator_step_instance._stub.ReqEstimationPostProcess.call_args.args[0]
+    assert len(request.counts) == 1
+    assert dict(request.counts[0].counts) == {"00": 10, "11": 20}
+    assert json.loads(request.grouped_operators) == [[["ZZ"]], [[1.0]]]
 
-    # expect expval by qiskit AerSimulator based Estimator
-    pubs = [(qasm3.loads(qasm_code), observable)]
-    aer_backend = AerSimulator()
-    estimator_qiskit = BackendEstimatorV2(backend=aer_backend)
-    job_qiskit = estimator_qiskit.run(pubs)
-    estimator_result = job_qiskit.result()
-    expect_expval = estimator_result[0].data["evs"]
-    expect_stds = estimator_result[0].data["stds"]
-
-    assert cmath.isclose(actual_expval, expect_expval, abs_tol=2e-1)
-    assert cmath.isclose(actual_stds, expect_stds, abs_tol=1e-1)
+    assert job.job_info.result is not None
+    assert job.job_info.result.estimation is not None
+    assert job.job_info.result.estimation.exp_value == 0.25
+    assert job.job_info.result.estimation.stds == 0.05
 
 
-def test_create_qiskit_operator_invalid_operator(
-    estimator_step_instance: EstimatorStep,
-):
-    # Test that ValueError is raised for invalid operator
-    operators = [
-        OperatorItem(pauli="Q0", coeff=1.0),  # Invalid Pauli label
-    ]
-    with pytest.raises(ValueError, match="The specified operator is invalid"):
-        estimator_step_instance.create_qiskit_operator(operators, 1)
+@pytest.mark.asyncio
+async def test_non_estimation_jobs_are_skipped(estimator_step_instance: EstimatorStep) -> None:
+    gctx = MagicMock()
+    jctx: dict[str, object] = {}
+    job = MagicMock()
+    job.job_id = "job-5"
+    job.job_type = "sampling"
 
+    await estimator_step_instance.pre_process(gctx, jctx, job)
+    await estimator_step_instance.post_process(gctx, jctx, job)
 
-def test_create_qiskit_operator_identity_with_index(
-    estimator_step_instance: EstimatorStep,
-):
-    # Test that 'I' with index is handled correctly
-    operators = [
-        OperatorItem(pauli="I 0", coeff=3.0),
-    ]
-    pauli_op = estimator_step_instance.create_qiskit_operator(operators, 2)
-    assert pauli_op.to_list()[0][0] == "II"
-    assert pauli_op.to_list()[0][1] == complex(3.0, 0.0)
-
-
-def test__post_process_multiple_counts(estimator_step_instance):
-    # Test _post_process with multiple counts and operators
-    counts_list = [
-        {"0": 100, "1": 0},
-        {"0": 50, "1": 50},
-    ]
-    grouped_operators = [[["X"], ["Z"]], [[1.0], [2.0]]]
-    expval, stds = estimator_step_instance._post_process(
-        counts_list, grouped_operators
-    )
-    assert isinstance(expval, (float, np.floating))
-    assert isinstance(stds, (float, np.floating))
-
-
-def test__pre_process_no_virtual_physical_mapping(
-    estimator_step_instance: EstimatorStep,
-):
-    # Test _pre_process with no virtual_physical_mapping
-    qasm_code = """
-    OPENQASM 3;
-    include "stdgates.inc";
-    qubit[2] q;
-    x q[0];
-    """
-    input_operators = [OperatorItem(pauli="X 0", coeff=1.0)]
-    basis_gates = ["cx", "id", "rz", "sx", "x", "reset", "delay", "measure"]
-    preprocessed_qasms, grouped_operators = estimator_step_instance._pre_process(
-        qasm_code=qasm_code,
-        operators=input_operators,
-        virtual_physical_mapping=None,
-        basis_gates=basis_gates,
-    )
-    assert isinstance(preprocessed_qasms, list)
-    assert isinstance(grouped_operators, list)
-    assert preprocessed_qasms
-    assert grouped_operators
-
-
-def test__pre_process_virtual_physical_mapping_extra(estimator_step_instance):
-    # Test _pre_process with virtual_physical_mapping that has missing indices
-    qasm_code = """
-    OPENQASM 3;
-    include "stdgates.inc";
-    qubit[3] q;
-    x q[0];
-    """
-    input_operators = [OperatorItem(pauli="X 0", coeff=1.0)]
-    virtual_physical_mapping = {"0": 2, "1": 0}  # missing "2"
-    basis_gates = ["cx", "id", "rz", "sx", "x", "reset", "delay", "measure"]
-    preprocessed_qasms, grouped_operators = estimator_step_instance._pre_process(
-        qasm_code=qasm_code,
-        operators=input_operators,
-        virtual_physical_mapping=virtual_physical_mapping,
-        basis_gates=basis_gates,
-    )
-    assert isinstance(preprocessed_qasms, list)
-    assert isinstance(grouped_operators, list)
-    assert preprocessed_qasms
-    assert grouped_operators
-
-
-def translate_operator2string(op: SparsePauliOp) -> list:
-    output = []
-    for term in op.to_list():
-        orig_operator = term[0]
-        list_operator = list(orig_operator)
-        list_operator.reverse()
-        operator = ""
-        for i, pauli in enumerate(list_operator):
-            operator += " ".join([pauli, str(i)]) + " "
-        operator = operator.rstrip()
-        coefficient = term[1]
-        body = [operator, coefficient.real]
-        output.append(body)
-    return output
+    estimator_step_instance._stub.ReqEstimationPreProcess.assert_not_awaited()
+    estimator_step_instance._stub.ReqEstimationPostProcess.assert_not_awaited()

--- a/core/tests/oqtopus_engine_core/steps/test_ro_error_mitigation_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_ro_error_mitigation_step.py
@@ -1,330 +1,148 @@
 import json
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 
 from oqtopus_engine_core.steps.ro_error_mitigation_step import ReadoutErrorMitigationStep
 
 
 @pytest.fixture
-def setup_mocks():
+def setup_sampling_job():
     gctx = MagicMock()
-    jctx = MagicMock()
+    gctx.device.device_info = json.dumps(
+        {
+            "qubits": [
+                {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
+                {"meas_error": {"prob_meas1_prep0": 0.03, "prob_meas0_prep1": 0.04}},
+            ]
+        }
+    )
+
+    jctx: dict[str, object] = {}
+
     job = MagicMock()
-
-    # Set up device info
-    device_info = {
-        "qubits": [
-            {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
-            {"meas_error": {"prob_meas1_prep0": 0.03, "prob_meas0_prep1": 0.04}},
-        ]
-    }
-    gctx.device.device_info = json.dumps(device_info)
-
-    # Set up job info
-    job.shots = 1000
+    job.job_id = "job-1"
+    job.job_type = "sampling"
+    job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
+    job.job_info.program = ["OPENQASM 3.0;\n"]
     job.job_info.result.sampling.counts = {"00": 500, "01": 300, "10": 150, "11": 50}
 
     return gctx, jctx, job
 
 
-@pytest.mark.asyncio
-async def test_post_process_with_ro_error_mitigation_no_transpile(setup_mocks):
-    gctx, jctx, job = setup_mocks
+@pytest.fixture
+def mitigation_step() -> ReadoutErrorMitigationStep:
+    step = ReadoutErrorMitigationStep("localhost:52011")
+    step._stub = MagicMock()
+    step._stub.ReqMitigation = AsyncMock()
+    return step
 
-    # Configure job for testing
-    job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
-    job.job_info.transpile_result = None
-    job.job_info.program = [MagicMock()]
-    job.job_info.program[0] = (
-        'OPENQASM 3.0;\ninclude "stdgates.inc";\nqubit[2] q;\nh q[0];\ncx q[0], q[1];\n'
+
+@pytest.mark.asyncio
+async def test_post_process_sampling_calls_grpc_and_updates_counts(
+    setup_sampling_job,
+    mitigation_step: ReadoutErrorMitigationStep,
+) -> None:
+    gctx, jctx, job = setup_sampling_job
+    mitigation_step._stub.ReqMitigation.return_value = SimpleNamespace(
+        counts={"00": 480, "01": 320, "10": 140, "11": 60}
     )
 
-    # Create mock for ro_error_mitigation
-    mitigated_counts = {"00": 480, "01": 320, "10": 140, "11": 60}
-    step = ReadoutErrorMitigationStep()
-    step.ro_error_mitigation = MagicMock(return_value=mitigated_counts)
+    await mitigation_step.post_process(gctx, jctx, job)
 
-    # Execute post_process
-    await step.post_process(gctx, jctx, job)
+    mitigation_step._stub.ReqMitigation.assert_awaited_once()
+    request = mitigation_step._stub.ReqMitigation.call_args.args[0]
 
-    # Verify ro_error_mitigation was called with correct parameters
-    step.ro_error_mitigation.assert_called_once()
-    args = step.ro_error_mitigation.call_args[0]
-    device_info = json.loads(gctx.device.device_info)
-    assert args[0] == device_info["qubits"]
-    assert args[2] == job.shots
-    assert args[3] == {"0": 0, "1": 1}
+    assert dict(request.counts) == {"00": 500, "01": 300, "10": 150, "11": 50}
+    assert request.program == "OPENQASM 3.0;\n"
+    assert len(request.device_topology.qubits) == 2
+    assert request.device_topology.qubits[0].mes_error.p0m1 == pytest.approx(0.01)
+    assert request.device_topology.qubits[0].mes_error.p1m0 == pytest.approx(0.02)
+    assert request.device_topology.qubits[1].mes_error.p0m1 == pytest.approx(0.03)
+    assert request.device_topology.qubits[1].mes_error.p1m0 == pytest.approx(0.04)
 
-    # Verify job counts were updated
-    assert job.job_info.result.sampling.counts == mitigated_counts
-
-
-@pytest.mark.asyncio
-async def test_post_process_with_ro_error_mitigation_with_transpile(setup_mocks):
-    gctx, jctx, job = setup_mocks
-
-    # Configure job for testing
-    job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
-    job.job_info.transpile_result = MagicMock()
-    job.job_info.transpile_result.virtual_physical_mapping = {
-        "qubit_mapping": {"0": 1, "1": 0}  # Swap qubits 0 and 1
+    assert job.job_info.result.sampling.counts == {
+        "00": 480,
+        "01": 320,
+        "10": 140,
+        "11": 60,
     }
 
-    # Create mock for ro_error_mitigation
-    mitigated_counts = {"00": 490, "01": 310, "10": 145, "11": 55}
-    step = ReadoutErrorMitigationStep()
-    step.ro_error_mitigation = MagicMock(return_value=mitigated_counts)
-
-    # Execute post_process
-    await step.post_process(gctx, jctx, job)
-
-    # Verify ro_error_mitigation was called with correct parameters
-    step.ro_error_mitigation.assert_called_once()
-    args = step.ro_error_mitigation.call_args[0]
-    device_info = json.loads(gctx.device.device_info)
-    assert args[0] == device_info["qubits"]
-    # assert args[1] == job.job_info.result.sampling.counts
-    assert args[2] == job.shots
-    assert args[3] == {"0": 1, "1": 0}
-
-    # Verify job counts were updated
-    assert job.job_info.result.sampling.counts == mitigated_counts
-
 
 @pytest.mark.asyncio
-async def test_post_process_with_null_mitigation_info(setup_mocks):
-    gctx, jctx, job = setup_mocks
+async def test_post_process_skips_when_mitigation_is_unset(
+    setup_sampling_job,
+    mitigation_step: ReadoutErrorMitigationStep,
+) -> None:
+    gctx, jctx, job = setup_sampling_job
+    original_counts = dict(job.job_info.result.sampling.counts)
 
-    # Configure job with null mitigation info
-    job.mitigation_info = {"ro_error_mitigation": None}
-    original_counts = job.job_info.result.sampling.counts.copy()
-
-    # Create step
-    step = ReadoutErrorMitigationStep()
-    step.ro_error_mitigation = MagicMock()
-
-    # Execute post_process
-    await step.post_process(gctx, jctx, job)
-
-    # Verify ro_error_mitigation was not called
-    step.ro_error_mitigation.assert_not_called()
-
-    # Verify job counts were not changed
-    assert job.job_info.result.sampling.counts == original_counts
-
-
-@pytest.mark.asyncio
-async def test_post_process_without_mitigation_info(setup_mocks):
-    gctx, jctx, job = setup_mocks
-
-    # Configure job without mitigation info
     job.mitigation_info = {}
-    original_counts = job.job_info.result.sampling.counts.copy()
+    await mitigation_step.post_process(gctx, jctx, job)
 
-    # Create step
-    step = ReadoutErrorMitigationStep()
-    step.ro_error_mitigation = MagicMock()
+    job.mitigation_info = {"ro_error_mitigation": None}
+    await mitigation_step.post_process(gctx, jctx, job)
 
-    # Execute post_process
-    with patch("oqtopus_engine_core.steps.ro_error_mitigation_step.logger") as mock_logger:
-        await step.post_process(gctx, jctx, job)
-
-    # Verify ro_error_mitigation was not called
-    step.ro_error_mitigation.assert_not_called()
-
-    # Verify job counts were not changed
+    mitigation_step._stub.ReqMitigation.assert_not_awaited()
     assert job.job_info.result.sampling.counts == original_counts
 
-    # Verify logger was called
-    mock_logger.debug.assert_called_with(
-        "ro_error_mitigation is not set in job.mitigation_info. "
-        "Skipping Readout Error Mitigation Step."
+
+@pytest.mark.asyncio
+async def test_post_process_estimation_uses_preprocessed_qasm_and_fallback(
+    mitigation_step: ReadoutErrorMitigationStep,
+) -> None:
+    gctx = MagicMock()
+    gctx.device.device_info = json.dumps(
+        {
+            "qubits": [
+                {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
+            ]
+        }
     )
 
+    job = MagicMock()
+    job.job_id = "job-2"
+    job.job_type = "estimation"
+    job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
+    job.job_info.program = ["fallback-program"]
 
-def test_ro_error_mitigation_basic() -> None:
-    """Test basic functionality of ro_error_mitigation with simple inputs.
+    estimation_job_info = SimpleNamespace(
+        counts_list=[{"0": 10}, {"1": 20}],
+        preprocessed_qasms=["qasm-0"],
+    )
+    jctx = {"estimation_job_info": estimation_job_info}
 
-    Raises:
-        ValueError: If the result does not match the expected counts.
-
-    """
-    # Mock qubits data
-    qubits = [
-        {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
-        {"meas_error": {"prob_meas1_prep0": 0.03, "prob_meas0_prep1": 0.04}},
-    ]
-    # Mock counts, shots and mapping
-    counts = {"00": 500, "01": 300, "10": 150, "11": 50}
-    shots = 1000
-    virtual_physical_mapping = {"0": 0, "1": 1}
-
-    # Create the step
-    step = ReadoutErrorMitigationStep()
-
-    # Mock the LocalReadoutMitigator and related functionality
-    with (
-        patch(
-            "oqtopus_engine_core.steps.ro_error_mitigation_step.LocalReadoutMitigator"
-        ) as mock_mitigator_cls,
-        patch(
-            "oqtopus_engine_core.steps.ro_error_mitigation_step.Counts"
-        ) as mock_counts_cls,
-        patch(
-            "oqtopus_engine_core.steps.ro_error_mitigation_step.np.array",
-            return_value="mock_array",
-        ),
-    ):
-        # Set up the mock mitigator
-        mock_mitigator = mock_mitigator_cls.return_value
-        mock_quasi_dist = mock_mitigator.quasi_probabilities.return_value
-        mock_nearest_prob = (
-            mock_quasi_dist.nearest_probability_distribution.return_value
-        )
-        mock_binary_probs = mock_nearest_prob.binary_probabilities.return_value
-
-        # Set the binary probabilities result
-        mock_binary_probs = {"00": 0.48, "01": 0.32, "10": 0.14, "11": 0.06}
-        mock_nearest_prob.binary_probabilities.return_value = mock_binary_probs
-
-        # Call the method
-        result = step.ro_error_mitigation(
-            qubits, counts, shots, virtual_physical_mapping
-        )
-
-        # Verify the expected calls
-        mock_mitigator_cls.assert_called_once()
-        mock_counts_cls.assert_called_once_with(
-            {"0b00": 500, "0b01": 300, "0b10": 150, "0b11": 50}, memory_slots=2
-        )
-        mock_mitigator.quasi_probabilities.assert_called_once()
-        mock_quasi_dist.nearest_probability_distribution.assert_called_once()
-        mock_nearest_prob.binary_probabilities.assert_called_once_with(num_bits=2)
-
-        # Check the result
-        expected_result = {"00": 480, "01": 320, "10": 140, "11": 60}
-        assert result == expected_result, (
-            f"Expected {expected_result}, but got {result}"
-        )
-
-
-def test_ro_error_mitigation_with_qubit_reordering():
-    """Test ro_error_mitigation with reordered qubits."""
-    # Mock qubits data
-    qubits = [
-        {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
-        {"meas_error": {"prob_meas1_prep0": 0.03, "prob_meas0_prep1": 0.04}},
+    mitigation_step._stub.ReqMitigation.side_effect = [
+        SimpleNamespace(counts={"0": 9}),
+        SimpleNamespace(counts={"1": 19}),
     ]
 
-    # Mock counts, shots and mapping with reordered qubits
-    counts = {"00": 500, "01": 300, "10": 150, "11": 50}
-    shots = 1000
-    virtual_physical_mapping = {"0": 1, "1": 0}  # Swap qubits 0 and 1
+    await mitigation_step.post_process(gctx, jctx, job)
 
-    step = ReadoutErrorMitigationStep()
+    assert mitigation_step._stub.ReqMitigation.await_count == 2
+    first_request = mitigation_step._stub.ReqMitigation.await_args_list[0].args[0]
+    second_request = mitigation_step._stub.ReqMitigation.await_args_list[1].args[0]
 
-    # Create a partial mock of the method to verify the sorted order
-    with patch.object(
-        step, "ro_error_mitigation", wraps=step.ro_error_mitigation
-    ) as spy_method:
-        try:
-            spy_method(qubits, counts, shots, virtual_physical_mapping)
-        except Exception:
-            pass  # We're just checking the sorted order, not the full execution
-
-        # Get the sorted_vpm from the spy call
-        sorted_vpm = None
-        for call in spy_method.mock_calls:
-            call_name, call_args, call_kwargs = call
-            if len(call_args) > 0 and isinstance(call_args[0], list):
-                # Find where sorted_vpm is created in the method
-                sorted_vpm = sorted(
-                    virtual_physical_mapping.items(),
-                    key=lambda item: int(item[0]),
-                )
-                break
-
-        # Verify the sorted order
-        assert sorted_vpm == [("0", 1), ("1", 0)]
+    assert first_request.program == "qasm-0"
+    assert second_request.program == "fallback-program"
+    assert estimation_job_info.counts_list == [{"0": 9}, {"1": 19}]
 
 
-def test_ro_error_mitigation_too_many_qubits():
-    """Test ro_error_mitigation raises ValueError when there are too many qubits."""
-    step = ReadoutErrorMitigationStep()
+@pytest.mark.asyncio
+async def test_post_process_estimation_without_counts_list_returns_early(
+    mitigation_step: ReadoutErrorMitigationStep,
+) -> None:
+    gctx = MagicMock()
+    gctx.device.device_info = json.dumps({"qubits": []})
 
-    # Create a large virtual_physical_mapping
-    virtual_physical_mapping = {str(i): i for i in range(33)}  # More than 32 qubits
+    job = MagicMock()
+    job.job_id = "job-3"
+    job.job_type = "estimation"
+    job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
 
-    with pytest.raises(ValueError) as excinfo:
-        step.ro_error_mitigation(
-            qubits=[{}] * 33,  # Not used due to early failure
-            counts={},  # Not used due to early failure
-            shots=1000,  # Not used due to early failure
-            virtual_physical_mapping=virtual_physical_mapping,
-        )
+    jctx = {"estimation_job_info": SimpleNamespace(counts_list=None)}
 
-    assert "input measured_qubits is too large" in str(excinfo.value)
+    await mitigation_step.post_process(gctx, jctx, job)
 
-
-def test_ro_error_mitigation_integration():
-    """Integration test for ro_error_mitigation with real objects."""
-    # Create real qubits data
-    qubits = [
-        {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
-        {"meas_error": {"prob_meas1_prep0": 0.03, "prob_meas0_prep1": 0.04}},
-    ]
-
-    counts = {"00": 500, "01": 300, "10": 150, "11": 50}
-    shots = 1000
-    virtual_physical_mapping = {"0": 0, "1": 1}
-
-    step = ReadoutErrorMitigationStep()
-
-    # Create mocks for qiskit objects
-    with (
-        patch(
-            "oqtopus_engine_core.steps.ro_error_mitigation_step.LocalReadoutMitigator"
-        ) as mock_mitigator_cls,
-        patch(
-            "oqtopus_engine_core.steps.ro_error_mitigation_step.Counts"
-        ) as mock_counts_cls,
-        patch("oqtopus_engine_core.steps.ro_error_mitigation_step.np", wraps=np) as mock_np,
-    ):
-        # Configure the mocks
-        mock_mitigator = mock_mitigator_cls.return_value
-        mock_quasi_dist = MagicMock()
-        mock_nearest_prob = MagicMock()
-        mock_mitigator.quasi_probabilities.return_value = mock_quasi_dist
-        mock_quasi_dist.nearest_probability_distribution.return_value = (
-            mock_nearest_prob
-        )
-        mock_nearest_prob.binary_probabilities.return_value = {
-            "00": 0.48,
-            "01": 0.32,
-            "10": 0.14,
-            "11": 0.06,
-        }
-
-        result = step.ro_error_mitigation(
-            qubits, counts, shots, virtual_physical_mapping
-        )
-
-        # Check call to np.array was made correctly
-        assert mock_np.array.call_count == 2
-
-        # Check matrices were created correctly
-        a_matrices = []
-        for call in mock_np.array.call_args_list:
-            a_matrices.append(call[0][0])
-
-        expected_matrix1 = [[1 - 0.01, 0.02], [0.01, 1 - 0.02]]
-        expected_matrix2 = [[1 - 0.03, 0.04], [0.03, 1 - 0.04]]
-
-        # Check array contents approximately
-        np.testing.assert_allclose(a_matrices[0], expected_matrix1)
-        np.testing.assert_allclose(a_matrices[1], expected_matrix2)
-
-        # Check the final result
-        assert result == {"00": 480, "01": 320, "10": 140, "11": 60}
+    mitigation_step._stub.ReqMitigation.assert_not_awaited()


### PR DESCRIPTION
## Summary
This PR fixes failing tests in `core` by aligning them with the current gRPC-based implementations of `EstimatorStep` and `ReadoutErrorMitigationStep`.

## Changes
- Updated `core/tests/oqtopus_engine_core/steps/test_estimator_step.py`
  - Removed dependencies on removed legacy methods (`create_qiskit_operator`, `_pre_process`, `_post_process`)
  - Rewrote tests to validate current `pre_process` / `post_process` behavior via mocked gRPC stubs:
    - `ReqEstimationPreProcess` request payload (operators string, `basis_gates`, sorted `mapping_list`)
    - `jctx["estimation_job_info"]` updates
    - `ValueError` when operator is missing
    - `ReqEstimationPostProcess` call and result propagation to `job.job_info.result.estimation`
    - skip behavior for non-`estimation` job types

- Updated `core/tests/oqtopus_engine_core/steps/test_ro_error_mitigation_step.py`
  - Updated construction to current signature: `ReadoutErrorMitigationStep(mitigator_address)`
  - Replaced legacy local-function expectations with gRPC-flow tests:
    - sampling job mitigation request/response and counts update
    - skip behavior when mitigation is unset
    - estimation job handling with preprocessed QASM and fallback program
    - early return when `counts_list` is `None`

## Root Cause
The tests were still written for an older local-helper-based design, while the step implementations have moved to gRPC-driven workflows. This caused `AttributeError` and `TypeError` failures.

## Validation
- Targeted tests:
  - `uv run --directory core pytest -q tests/oqtopus_engine_core/steps/test_estimator_step.py tests/oqtopus_engine_core/steps/test_ro_error_mitigation_step.py`
  - Result: `9 passed`
- Full `core` test suite:
  - `uv run --directory core pytest -q`
  - Result: `89 passed` (existing warning: `Unknown config option: env`)

## Impact
- Test-only changes in `core`.
- No production code changes.
