### PR TITLE
feat: Use docker internal network for SSE communication instead of host ports

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -103,7 +103,7 @@ di_container:
     sse_step:
       _target_: oqtopus_engine_core.steps.sse_step.SseStep
       runner_settings:
-        sse_engine_port: ${SSE_GATEWAY_ROUTER_LISTEN_PORT, 52014}
+        sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:52014"}
         host_work_path: ${SSE_HOST_WORK_PATH, "/sse_work"}
         delete_host_temp_dirs: ${SSE_DELETE_HOST_TEMP_DIRS, true}
         container_work_path: ${SSE_CONTAINER_PATH, "/sse"}
@@ -114,6 +114,9 @@ di_container:
         container_disk_quota: ${SSE_CONTAINER_DISK_QUOTA, 67108864}
         container_memory: ${SSE_CONTAINER_MEMORY, 268435456}
         container_cpu_set: ${SSE_CONTAINER_CPU_SET, "0"}
+        container_network: ${SSE_CONTAINER_NETWORK, "context_app_net"}
+        container_extra_hosts:
+          - sse_engine: ${SSE_ENGINE_IP, "localhost"}
         timeout: ${SSE_TIMEOUT, 600}
         max_file_size: ${SSE_MAX_FILE_SIZE, 10485760}
 

--- a/core/src/oqtopus_engine_core/steps/sse_step.py
+++ b/core/src/oqtopus_engine_core/steps/sse_step.py
@@ -463,7 +463,8 @@ class SseRunner:
                 "initializing SSE container",
                 extra={"job_id": self._job_id},
             )
-            cmd = f'sh -c "/root/init.sh {self._config["sse_engine_port"]}"'
+            port = self._config["sse_engine_address"].split(":")[-1]
+            cmd = f'sh -c "/root/init.sh {port}"'
             await self._exec_in_container(
                 user="root",
                 privileged=True,
@@ -611,7 +612,7 @@ class SseRunner:
             f"JOB_JSON={self._job.model_dump_json()}",
             f"IN_PATH={self._container_work_path['in']}",
             f"OUT_PATH={self._container_work_path['out']}",
-            f"GRPC_SSE_ENGINE_PORT={self._config['sse_engine_port']}",
+            f"SSE_ENGINE_ADDRESS={self._config['sse_engine_address']}",
             "TERM=dumb",  # to drop ANSI escape codes in logs
         ]
 
@@ -626,7 +627,8 @@ class SseRunner:
             mounts=[tmpfs],
             mem_limit=self._config.get("container_memory", 256 * 1024 * 1024),
             cpuset_cpus=self._config.get("container_cpu_set", "0"),
-            extra_hosts={"host.docker.internal": "host-gateway"},
+            network=self._config.get("container_network", None),
+            extra_hosts=self._config.get("container_extra_hosts", None),
         )
         logger.debug(
             "started SSE container successfully",

--- a/sse_runtime/src/sse_runtime/sse_sampler.py
+++ b/sse_runtime/src/sse_runtime/sse_sampler.py
@@ -37,8 +37,8 @@ def req_transpile_and_exec(
         BackendError: If the job execution fails.
 
     """
-    # get gRPC server port from environment variables
-    grpc_sse_engine_port = os.environ.get("GRPC_SSE_ENGINE_PORT", "5001")
+    # get gRPC server address from environment variables
+    grpc_sse_engine_address = os.environ.get("SSE_ENGINE_ADDRESS", "localhost:52014")
 
     # get job data from environment variable
     job_json = os.environ.get("JOB_JSON")
@@ -46,9 +46,7 @@ def req_transpile_and_exec(
         msg = "Could not get job data"
         raise OSError(msg)
 
-    with grpc.insecure_channel(
-        f"host.docker.internal:{grpc_sse_engine_port}"
-    ) as channel:
+    with grpc.insecure_channel(f"{grpc_sse_engine_address}") as channel:
         created = datetime.datetime.now(tz=datetime.UTC) \
                                     .strftime("%Y-%m-%d %H:%M:%S")
         stub = sse_pb2_grpc.SseEngineServiceStub(channel)
@@ -87,6 +85,9 @@ def _make_job_def(
     result_dict = json.loads(response.job_json or "{}")
     result_dict["name"] = result_dict["name"] or ""
 
+    # Filter out unsupported fields to ensure compatibility with JobsJobDef
+    for key in ["parent", "children"]:
+        result_dict.pop(key, None)
     # Convert to JobsJobDef
     job = JobsJobDef(**result_dict)
     # Convert job_info and its nested objects


### PR DESCRIPTION
## ✍ Description

Refactored the communication between the simulation client and `sse_engine` to use Docker's internal network instead of relying on host-side port mapping.
