### PR TITLE
fix: remove unnecessary spaces and quotes in container_extra_hosts

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -116,7 +116,7 @@ di_container:
         container_cpu_set: ${SSE_CONTAINER_CPU_SET, "0"}
         container_network: ${SSE_CONTAINER_NETWORK, "context_app_net"}
         container_extra_hosts:
-          - sse_engine: ${SSE_ENGINE_IP, "localhost"}
+          - sse_engine:${SSE_ENGINE_IP, localhost}
         timeout: ${SSE_TIMEOUT, 600}
         max_file_size: ${SSE_MAX_FILE_SIZE, 10485760}
 


### PR DESCRIPTION
# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description

Fixed the configuration format for container_extra_hosts to resolve a Docker API error.

The previous configuration was passing a list of dictionaries (e.g., `[{'host': 'ip'}]`) and contained unnecessary spaces or quotes, which caused the following Docker API error:
`"invalid JSON: json: cannot unmarshal object into Go struct field HostConfig.HostConfig.ExtraHosts of type string"`
