### PR TITLE
Feat/estimator same step split join

### DIFF
--- a/combiner/uv.lock
+++ b/combiner/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:07:20.82525758Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "absl-py"
 version = "2.3.1"

--- a/core/src/oqtopus_engine_core/framework/__init__.py
+++ b/core/src/oqtopus_engine_core/framework/__init__.py
@@ -16,7 +16,7 @@ from .model import (
     SamplingResult,
     TranspileResult,
 )
-from .pipeline import HAS_ACTUAL_CHILDREN_KEY, PipelineExecutor
+from .pipeline import PipelineExecutor
 from .pipeline_builder import PipelineBuilder
 from .step import (
     DetachOnPostprocess,
@@ -38,7 +38,6 @@ __all__ = [
     "Engine",
     "EstimationResult",
     "GlobalContext",
-    "HAS_ACTUAL_CHILDREN_KEY",
     "Job",
     "JobContext",
     "JobFetcher",

--- a/core/src/oqtopus_engine_core/framework/__init__.py
+++ b/core/src/oqtopus_engine_core/framework/__init__.py
@@ -16,7 +16,7 @@ from .model import (
     SamplingResult,
     TranspileResult,
 )
-from .pipeline import PipelineExecutor
+from .pipeline import HAS_ACTUAL_CHILDREN_KEY, PipelineExecutor
 from .pipeline_builder import PipelineBuilder
 from .step import (
     DetachOnPostprocess,
@@ -38,6 +38,7 @@ __all__ = [
     "Engine",
     "EstimationResult",
     "GlobalContext",
+    "HAS_ACTUAL_CHILDREN_KEY",
     "Job",
     "JobContext",
     "JobFetcher",

--- a/core/src/oqtopus_engine_core/framework/context.py
+++ b/core/src/oqtopus_engine_core/framework/context.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict
 
 from .device_repository import DeviceRepository  # noqa: TC001
 from .job_repository import JobRepository  # noqa: TC001
-from .model import Device  # noqa: TC001
+from .model import Device, Job  # noqa: TC001
 
 
 class GlobalContext(BaseModel):
@@ -126,3 +126,38 @@ class JobContext(UserDict):
         else:
             message = f"{self.__class__.__name__!r} object has no attribute {name!r}"
             raise AttributeError(message)
+
+
+def link_parent_and_children(
+    parent_jctx: JobContext,
+    parent_job: Job,
+    child_jctxs: list[JobContext],
+    child_jobs: list[Job],
+) -> None:
+    """Establish bidirectional links between parent and children.
+
+    This utility ensures that both Job and JobContext trees are consistent
+    by setting 'children' on the parent and 'parent' on each child.
+
+    Args:
+        parent_jctx: The JobContext associated with the parent job.
+        parent_job: The parent Job object.
+        child_jctxs: A list of JobContext objects corresponding to each child job.
+        child_jobs: A list of child Job objects to be linked to the parent.
+
+    Raises:
+        ValueError: If the number of child jobs and child contexts do not match.
+
+    """
+    if len(child_jobs) != len(child_jctxs):
+        message = "The number of child jobs and child contexts must match."
+        raise ValueError(message)
+
+    # Parent -> Children
+    parent_job.children = child_jobs
+    parent_jctx.children = child_jctxs
+
+    # Children -> Parent
+    for c_job, c_jctx in zip(child_jobs, child_jctxs, strict=True):
+        c_job.parent = parent_job
+        c_jctx.parent = parent_jctx

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+HAS_ACTUAL_CHILDREN_KEY = "has_actual_children"
+
 
 class StepPhase(StrEnum):
     """Execution phase of a pipeline step."""
@@ -610,6 +612,7 @@ class PipelineExecutor:
         # ------------------------------------------------------------
         parent_id = job.job_id
         child_count = len(job.children)
+        jctx[HAS_ACTUAL_CHILDREN_KEY] = True
         async with self._pending_children_lock:
             # Overwrite is allowed but indicates a nested split on the same parent.
             # For now we just log it to make debugging easier.
@@ -642,6 +645,7 @@ class PipelineExecutor:
             # Establish parent link
             child_job.parent = job
             child_jctx.parent = jctx
+            child_jctx.setdefault(HAS_ACTUAL_CHILDREN_KEY, False)
 
             # Enqueue child pipelines as coroutines; they will run concurrently
             # via asyncio.gather below.

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+POST_RETURN_SPLIT_INDEX_KEY = "_post_return_split_index"
+POST_RETURN_ACTIVE_INDEX_KEY = "_post_return_active_index"
+
 
 class StepPhase(StrEnum):
     """Execution phase of a pipeline step."""
@@ -198,6 +201,12 @@ class PipelineExecutor:
                     continue
             # backward finished: no more nodes to process.
             elif cursor < 0:
+                post_return_index = jctx.pop(POST_RETURN_SPLIT_INDEX_KEY, None)
+                if post_return_index is not None:
+                    jctx[POST_RETURN_ACTIVE_INDEX_KEY] = post_return_index
+                    cursor = post_return_index
+                    continue
+
                 # When a child job finishes its entire pipeline without
                 # triggering a join, we must decrement the pending-children
                 # counters to avoid resource leaks. This will also cascade
@@ -295,6 +304,7 @@ class PipelineExecutor:
                 if self._is_split_enabled(node, jctx, SplitOnPreprocess):
                     await self._handle_split(
                         step=node,
+                        step_index=cursor,
                         step_phase=StepPhase.PRE_PROCESS,
                         next_index=next_cursor,
                         gctx=gctx,
@@ -371,6 +381,7 @@ class PipelineExecutor:
                     # the step immediately after the splitter.
                     await self._handle_split(
                         step=node,
+                        step_index=cursor,
                         step_phase=StepPhase.POST_PROCESS,
                         next_index=next_cursor,
                         gctx=gctx,
@@ -378,6 +389,12 @@ class PipelineExecutor:
                         job=job,
                     )
                     return  # stop backward execution for the current job.
+
+            active_post_return_index = jctx.get(POST_RETURN_ACTIVE_INDEX_KEY)
+            if active_post_return_index == cursor:
+                del jctx[POST_RETURN_ACTIVE_INDEX_KEY]
+                cursor = -1
+                continue
 
             # for non-step nodes in POST_PROCESS (unexpected) or normal steps,
             # simply move to the previous index.
@@ -536,6 +553,7 @@ class PipelineExecutor:
     async def _handle_split(  # noqa: PLR0913, PLR0917
         self,
         step: Step,
+        step_index: int,
         step_phase: StepPhase,
         next_index: int,
         gctx: GlobalContext,
@@ -642,6 +660,14 @@ class PipelineExecutor:
             # Establish parent link
             child_job.parent = job
             child_jctx.parent = jctx
+
+            # Allow a PRE split step to receive child POST callbacks only when
+            # the same step also performs a POST join.
+            if (
+                step_phase == StepPhase.PRE_PROCESS
+                and isinstance(step, JoinOnPostprocess)
+            ):
+                child_jctx[POST_RETURN_SPLIT_INDEX_KEY] = step_index
 
             # Enqueue child pipelines as coroutines; they will run concurrently
             # via asyncio.gather below.

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -610,7 +610,6 @@ class PipelineExecutor:
         # ------------------------------------------------------------
         parent_id = job.job_id
         child_count = len(job.children)
-        jctx["has_actual_children"] = True
         async with self._pending_children_lock:
             # Overwrite is allowed but indicates a nested split on the same parent.
             # For now we just log it to make debugging easier.
@@ -643,7 +642,6 @@ class PipelineExecutor:
             # Establish parent link
             child_job.parent = job
             child_jctx.parent = jctx
-            child_jctx.setdefault("has_actual_parent", True)
 
             # Enqueue child pipelines as coroutines; they will run concurrently
             # via asyncio.gather below.

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -26,8 +26,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-HAS_ACTUAL_CHILDREN_KEY = "has_actual_children"
-
 
 class StepPhase(StrEnum):
     """Execution phase of a pipeline step."""
@@ -612,7 +610,7 @@ class PipelineExecutor:
         # ------------------------------------------------------------
         parent_id = job.job_id
         child_count = len(job.children)
-        jctx[HAS_ACTUAL_CHILDREN_KEY] = True
+        jctx["has_actual_children"] = True
         async with self._pending_children_lock:
             # Overwrite is allowed but indicates a nested split on the same parent.
             # For now we just log it to make debugging easier.
@@ -645,7 +643,7 @@ class PipelineExecutor:
             # Establish parent link
             child_job.parent = job
             child_jctx.parent = jctx
-            child_jctx.setdefault(HAS_ACTUAL_CHILDREN_KEY, False)
+            child_jctx.setdefault("has_actual_parent", True)
 
             # Enqueue child pipelines as coroutines; they will run concurrently
             # via asyncio.gather below.

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -26,9 +26,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-POST_RETURN_SPLIT_INDEX_KEY = "_post_return_split_index"
-POST_RETURN_ACTIVE_INDEX_KEY = "_post_return_active_index"
-
 
 class StepPhase(StrEnum):
     """Execution phase of a pipeline step."""
@@ -201,12 +198,6 @@ class PipelineExecutor:
                     continue
             # backward finished: no more nodes to process.
             elif cursor < 0:
-                post_return_index = jctx.pop(POST_RETURN_SPLIT_INDEX_KEY, None)
-                if post_return_index is not None:
-                    jctx[POST_RETURN_ACTIVE_INDEX_KEY] = post_return_index
-                    cursor = post_return_index
-                    continue
-
                 # When a child job finishes its entire pipeline without
                 # triggering a join, we must decrement the pending-children
                 # counters to avoid resource leaks. This will also cascade
@@ -304,7 +295,6 @@ class PipelineExecutor:
                 if self._is_split_enabled(node, jctx, SplitOnPreprocess):
                     await self._handle_split(
                         step=node,
-                        step_index=cursor,
                         step_phase=StepPhase.PRE_PROCESS,
                         next_index=next_cursor,
                         gctx=gctx,
@@ -381,7 +371,6 @@ class PipelineExecutor:
                     # the step immediately after the splitter.
                     await self._handle_split(
                         step=node,
-                        step_index=cursor,
                         step_phase=StepPhase.POST_PROCESS,
                         next_index=next_cursor,
                         gctx=gctx,
@@ -389,12 +378,6 @@ class PipelineExecutor:
                         job=job,
                     )
                     return  # stop backward execution for the current job.
-
-            active_post_return_index = jctx.get(POST_RETURN_ACTIVE_INDEX_KEY)
-            if active_post_return_index == cursor:
-                del jctx[POST_RETURN_ACTIVE_INDEX_KEY]
-                cursor = -1
-                continue
 
             # for non-step nodes in POST_PROCESS (unexpected) or normal steps,
             # simply move to the previous index.
@@ -553,7 +536,6 @@ class PipelineExecutor:
     async def _handle_split(  # noqa: PLR0913, PLR0917
         self,
         step: Step,
-        step_index: int,
         step_phase: StepPhase,
         next_index: int,
         gctx: GlobalContext,
@@ -660,14 +642,6 @@ class PipelineExecutor:
             # Establish parent link
             child_job.parent = job
             child_jctx.parent = jctx
-
-            # Allow a PRE split step to receive child POST callbacks only when
-            # the same step also performs a POST join.
-            if (
-                step_phase == StepPhase.PRE_PROCESS
-                and isinstance(step, JoinOnPostprocess)
-            ):
-                child_jctx[POST_RETURN_SPLIT_INDEX_KEY] = step_index
 
             # Enqueue child pipelines as coroutines; they will run concurrently
             # via asyncio.gather below.

--- a/core/src/oqtopus_engine_core/framework/pipeline.py
+++ b/core/src/oqtopus_engine_core/framework/pipeline.py
@@ -639,10 +639,6 @@ class PipelineExecutor:
                 },
             )
 
-            # Establish parent link
-            child_job.parent = job
-            child_jctx.parent = jctx
-
             # Enqueue child pipelines as coroutines; they will run concurrently
             # via asyncio.gather below.
             child_coroutines.append(

--- a/core/src/oqtopus_engine_core/handlers/fail_job_repository_handler.py
+++ b/core/src/oqtopus_engine_core/handlers/fail_job_repository_handler.py
@@ -24,6 +24,11 @@ class FailJobRepositoryHandler(PipelineExceptionHandler):
         if jctx.get("has_actual_children", False):
             # if there are child jobs, update their status
             await self._update_jobs_status(ex, gctx, job.children)
+        elif jctx.get("has_actual_parent", False):
+            logger.info(
+                "skip repository failure update for internal child job",
+                extra={"job_id": job.job_id, "job_type": job.job_type},
+            )
         else:
             await self._update_jobs_status(ex, gctx, [job])
 

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -68,88 +68,93 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
             )
             return
 
-        async with self._execution_lock:
-            start = time.perf_counter()
+        start = time.perf_counter()
 
-            # Update job status for the combined children if this job is a parent,
-            # otherwise update only the current job.
+        # Update job status for the combined children if this job is a parent,
+        # otherwise update only the current job.
+        async with self._execution_lock:
             if jctx.get("has_actual_children", False):
                 await self._update_jobs_status(gctx, job.children)
             elif jctx.get("has_actual_parent", False):
-                logger.info(
-                    "skip repository status update for internal child job",
-                    extra={"job_id": job.job_id, "job_type": job.job_type},
-                )
+                parent_job = job.parent
+                # Update parent status if it is "ready"; otherwise, skip
+                if parent_job.status == "ready":
+                    await self._update_jobs_status(gctx, [parent_job])
+                else:
+                    logger.info(
+                        "skip repository status update for internal child job",
+                        extra={"job_id": job.job_id, "job_type": job.job_type},
+                    )
             else:
                 await self._update_jobs_status(gctx, [job])
 
-            # Check device status immediately before using the gateway.
-            service_status = await self._stub.GetServiceStatus(
-                qpu_pb2.GetServiceStatusRequest()
+        # Check device status immediately before using the gateway.
+        service_status = await self._stub.GetServiceStatus(
+            qpu_pb2.GetServiceStatusRequest()
+        )
+        logger.info(
+            "GetServiceStatus response",
+            extra={
+                "job_id": job.job_id,
+                "job_type": job.job_type,
+                "service_status": service_status.service_status,
+            },
+        )
+        if (
+            service_status.service_status
+            != qpu_pb2.ServiceStatus.SERVICE_STATUS_ACTIVE
+        ):
+            message = "device status is not available"
+            raise RuntimeError(message)
+
+        # Call device gateway
+        if job.job_type in {"sampling", "multi_manual"}:
+            job_request = qpu_pb2.CallJobRequest(
+                job_id=job.job_id,
+                shots=job.shots,
+                program=_select_program(job),
             )
             logger.info(
-                "GetServiceStatus response",
+                "CallJob request",
                 extra={
                     "job_id": job.job_id,
                     "job_type": job.job_type,
-                    "service_status": service_status.service_status,
+                    "job_request": job_request,
                 },
             )
-            if (
-                service_status.service_status
-                != qpu_pb2.ServiceStatus.SERVICE_STATUS_ACTIVE
-            ):
-                message = "device status is not available"
-                raise RuntimeError(message)
-
-            # Call device gateway
-            if job.job_type in {"sampling", "multi_manual"}:
-                job_request = qpu_pb2.CallJobRequest(
-                    job_id=job.job_id,
-                    shots=job.shots,
-                    program=_select_program(job),
-                )
-                logger.info(
-                    "CallJob request",
-                    extra={
-                        "job_id": job.job_id,
-                        "job_type": job.job_type,
-                        "job_request": job_request,
-                    },
-                )
-                job_response = await self._stub.CallJob(job_request)
-                if job_response.status != qpu_pb2.JobStatus.JOB_STATUS_SUCCESS:
-                    logger.error(
-                        "failed to execute job on device gateway",
-                        extra={
-                            "job_id": job.job_id,
-                            "job_type": job.job_type,
-                            "job_response": job_response,
-                        },
-                    )
-                    msg = "failed to execute job on device"
-                    raise RuntimeError(msg)
-                logger.info(
-                    "CallJob response",
+            job_response = await self._stub.CallJob(job_request)
+            if job_response.status != qpu_pb2.JobStatus.JOB_STATUS_SUCCESS:
+                logger.error(
+                    "failed to execute job on device gateway",
                     extra={
                         "job_id": job.job_id,
                         "job_type": job.job_type,
                         "job_response": job_response,
                     },
                 )
-                execution_time = time.perf_counter() - start
+                msg = "failed to execute job on device"
+                raise RuntimeError(msg)
+            logger.info(
+                "CallJob response",
+                extra={
+                    "job_id": job.job_id,
+                    "job_type": job.job_type,
+                    "job_response": job_response,
+                },
+            )
+            execution_time = time.perf_counter() - start
 
-                # Update job
-                job.execution_time = float(f"{execution_time:.3f}")
-                job.job_info.result = JobResult(
-                    sampling=SamplingResult(counts=job_response.result.counts)
-                )
-                job.job_info.message = job_response.result.message
-            elif job.job_type == "estimation":
-                message = (
-                    "estimation jobs must be split before reaching device gateway"
-                )
-                raise RuntimeError(message)
+            # Update job
+            job.execution_time = float(f"{execution_time:.3f}")
+            job.job_info.result = JobResult(
+                sampling=SamplingResult(counts=job_response.result.counts)
+            )
+            job.job_info.message = job_response.result.message
+        elif job.job_type == "estimation":
+            message = (
+                "estimation jobs must be split before reaching device gateway"
+            )
+            raise RuntimeError(message)
 
     async def post_process(
         self,

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 
@@ -31,6 +32,9 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
     def __init__(self, gateway_address: str = "localhost:50051") -> None:
         self._channel = grpc.aio.insecure_channel(gateway_address)
         self._stub = qpu_pb2_grpc.QpuServiceStub(self._channel)
+        # Engine owns device access orchestration, so all jobs, including
+        # internal estimation children, must serialize gateway execution here.
+        self._execution_lock = asyncio.Lock()
         logger.info(
             "DeviceGatewayStep was initialized with gateway_address=%s",
             gateway_address,
@@ -64,77 +68,81 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
             )
             return
 
-        start = time.perf_counter()
+        async with self._execution_lock:
+            start = time.perf_counter()
 
-        # Update job status
-        if jctx.get("has_actual_children", False):
-            # if there are child jobs, update their status
-            await self._update_jobs_status(gctx, job.children)
-        else:
-            await self._update_jobs_status(gctx, [job])
+            # Update externally visible job status only for non-internal jobs.
+            if not jctx.get(INTERNAL_JOB_KEY):
+                job.status = "running"
+                await gctx.job_repository.update_job_status_nowait(job)
 
-        # Check device status
-        service_status = await self._stub.GetServiceStatus(
-            qpu_pb2.GetServiceStatusRequest()
-        )
-        logger.info(
-            "GetServiceStatus response",
-            extra={
-                "job_id": job.job_id,
-                "job_type": job.job_type,
-                "service_status": service_status.service_status,
-            },
-        )
-        if service_status.service_status != qpu_pb2.ServiceStatus.SERVICE_STATUS_ACTIVE:
-            message = "device status is not available"
-            raise RuntimeError(message)
-
-        # Call device gateway
-        if job.job_type in {"sampling", "multi_manual"}:
-            job_request = qpu_pb2.CallJobRequest(
-                job_id=job.job_id,
-                shots=job.shots,
-                program=_select_program(job),
+            # Check device status immediately before using the gateway.
+            service_status = await self._stub.GetServiceStatus(
+                qpu_pb2.GetServiceStatusRequest()
             )
             logger.info(
-                "CallJob request",
+                "GetServiceStatus response",
                 extra={
                     "job_id": job.job_id,
                     "job_type": job.job_type,
-                    "job_request": job_request,
+                    "service_status": service_status.service_status,
                 },
             )
-            job_response = await self._stub.CallJob(job_request)
-            if job_response.status != qpu_pb2.JobStatus.JOB_STATUS_SUCCESS:
-                logger.error(
-                    "failed to execute job on device gateway",
+            if (
+                service_status.service_status
+                != qpu_pb2.ServiceStatus.SERVICE_STATUS_ACTIVE
+            ):
+                message = "device status is not available"
+                raise RuntimeError(message)
+
+            # Call device gateway
+            if job.job_type in {"sampling", "multi_manual"}:
+                job_request = qpu_pb2.CallJobRequest(
+                    job_id=job.job_id,
+                    shots=job.shots,
+                    program=_select_program(job),
+                )
+                logger.info(
+                    "CallJob request",
+                    extra={
+                        "job_id": job.job_id,
+                        "job_type": job.job_type,
+                        "job_request": job_request,
+                    },
+                )
+                job_response = await self._stub.CallJob(job_request)
+                if job_response.status != qpu_pb2.JobStatus.JOB_STATUS_SUCCESS:
+                    logger.error(
+                        "failed to execute job on device gateway",
+                        extra={
+                            "job_id": job.job_id,
+                            "job_type": job.job_type,
+                            "job_response": job_response,
+                        },
+                    )
+                    msg = "failed to execute job on device"
+                    raise RuntimeError(msg)
+                logger.info(
+                    "CallJob response",
                     extra={
                         "job_id": job.job_id,
                         "job_type": job.job_type,
                         "job_response": job_response,
                     },
                 )
-                msg = "failed to execute job on device"
-                raise RuntimeError(msg)
-            logger.info(
-                "CallJob response",
-                extra={
-                    "job_id": job.job_id,
-                    "job_type": job.job_type,
-                    "job_response": job_response,
-                },
-            )
-            execution_time = time.perf_counter() - start
+                execution_time = time.perf_counter() - start
 
-            # Update job
-            job.execution_time = float(f"{execution_time:.3f}")
-            job.job_info.result = JobResult(
-                sampling=SamplingResult(counts=job_response.result.counts)
-            )
-            job.job_info.message = job_response.result.message
-        elif job.job_type == "estimation":
-            message = "estimation jobs must be split before reaching device gateway"
-            raise RuntimeError(message)
+                # Update job
+                job.execution_time = float(f"{execution_time:.3f}")
+                job.job_info.result = JobResult(
+                    sampling=SamplingResult(counts=job_response.result.counts)
+                )
+                job.job_info.message = job_response.result.message
+            elif job.job_type == "estimation":
+                message = (
+                    "estimation jobs must be split before reaching device gateway"
+                )
+                raise RuntimeError(message)
 
     async def post_process(
         self,

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -13,6 +13,7 @@ from oqtopus_engine_core.framework import (
 )
 from oqtopus_engine_core.framework.step import DetachOnPostprocess
 from oqtopus_engine_core.interfaces.qpu_interface.v1 import qpu_pb2, qpu_pb2_grpc
+from oqtopus_engine_core.steps.estimator_step import INTERNAL_JOB_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -131,53 +132,9 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
                 sampling=SamplingResult(counts=job_response.result.counts)
             )
             job.job_info.message = job_response.result.message
-
         elif job.job_type == "estimation":
-            jctx["estimation_job_info"].counts_list = []
-            for program in jctx["estimation_job_info"].preprocessed_qasms:
-                logger.debug("program: %s", program)
-                job_request = qpu_pb2.CallJobRequest(
-                    job_id=job.job_id,
-                    shots=job.shots,
-                    program=program,
-                )
-                logger.info(
-                    "CallJob request",
-                    extra={
-                        "job_id": job.job_id,
-                        "job_type": job.job_type,
-                        "job_request": job_request,
-                    },
-                )
-                job_response = await self._stub.CallJob(job_request)
-                if job_response.status != qpu_pb2.JobStatus.JOB_STATUS_SUCCESS:
-                    logger.error(
-                        "failed to execute job on device gateway",
-                        extra={
-                            "job_id": job.job_id,
-                            "job_type": job.job_type,
-                            "job_response": job_response,
-                        },
-                    )
-                    msg = "failed to execute job on device"
-                    raise RuntimeError(msg)
-                logger.info(
-                    "CallJob response",
-                    extra={
-                        "job_id": job.job_id,
-                        "job_type": job.job_type,
-                        "job_response": job_response,
-                    },
-                )
-
-                jctx["estimation_job_info"].counts_list.append(
-                    job_response.result.counts
-                )
-            execution_time = time.perf_counter() - start
-
-            # Update job
-            job.execution_time = float(f"{execution_time:.3f}")
-            job.job_info.message = job_response.result.message
+            message = "estimation jobs must be split before reaching device gateway"
+            raise RuntimeError(message)
 
     async def post_process(
         self,

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -14,7 +14,6 @@ from oqtopus_engine_core.framework import (
 )
 from oqtopus_engine_core.framework.step import DetachOnPostprocess
 from oqtopus_engine_core.interfaces.qpu_interface.v1 import qpu_pb2, qpu_pb2_grpc
-from oqtopus_engine_core.steps.estimator_step import INTERNAL_JOB_KEY
 
 logger = logging.getLogger(__name__)
 

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -71,10 +71,17 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
         async with self._execution_lock:
             start = time.perf_counter()
 
-            # Update externally visible job status only for non-internal jobs.
-            if not jctx.get(INTERNAL_JOB_KEY):
-                job.status = "running"
-                await gctx.job_repository.update_job_status_nowait(job)
+            # Update job status for the combined children if this job is a parent,
+            # otherwise update only the current job.
+            if jctx.get("has_actual_children", False):
+                await self._update_jobs_status(gctx, job.children)
+            elif jctx.get("has_actual_parent", False):
+                logger.info(
+                    "skip repository status update for internal child job",
+                    extra={"job_id": job.job_id, "job_type": job.job_type},
+                )
+            else:
+                await self._update_jobs_status(gctx, [job])
 
             # Check device status immediately before using the gateway.
             service_status = await self._stub.GetServiceStatus(

--- a/core/src/oqtopus_engine_core/steps/device_gateway_step.py
+++ b/core/src/oqtopus_engine_core/steps/device_gateway_step.py
@@ -19,6 +19,114 @@ from oqtopus_engine_core.steps.estimator_step import INTERNAL_JOB_KEY
 logger = logging.getLogger(__name__)
 
 
+def _collect_status_update_targets(
+    jctx: JobContext,
+    job: Job,
+) -> list[Job]:
+    """Collect jobs to be updated.
+
+    Follows these steps:
+    1. Traverse down to find all reachable leaf children.
+    2. For each leaf children, traverse up to find all reachable root parents.
+
+    Args:
+        jctx: The job context of the current job.
+        job: The current job.
+
+    Returns:
+        A list of (JobContext, Job) tuples to be updated.
+
+    """
+    # Step 1: Find all terminal nodes at the bottom of the graph
+    # Returns a list[tuple[JobContext, Job]]
+    leaf_pairs = _find_all_leaf_jobs(jctx, job)
+
+    # Step 2: From each leaf, identify all paths leading to the top-level roots.
+    # We use a dictionary keyed by job_id for O(1) deduplication.
+    unique_jobs: dict[str, Job] = {}
+    visited_up: set[str] = set()
+
+    for leaf_jctx, leaf_job in leaf_pairs:
+        # Traverse upwards to find all roots
+        root_pairs = _find_all_root_jobs(leaf_jctx, leaf_job, visited=visited_up)
+        for _, root_job in root_pairs:
+            unique_jobs[root_job.job_id] = root_job
+
+    return list(unique_jobs.values())
+
+
+def _find_all_leaf_jobs(
+    jctx: JobContext,
+    job: Job,
+    visited: set[str] | None = None,
+) -> list[tuple[JobContext, Job]]:
+    """Recursively find all terminal leaf jobs.
+
+    Args:
+        jctx: The job context of the current job.
+        job: The current job.
+        visited: A set of job IDs that have already been visited to prevent cycles.
+
+    Returns:
+        A list of (JobContext, Job) tuples for all leaf jobs
+
+    """
+    if visited is None:
+        visited = set()
+
+    if job.job_id in visited:
+        return []
+    visited.add(job.job_id)
+
+    leaves: list[tuple[JobContext, Job]] = []
+
+    if jctx.get("has_actual_children", False):
+        # Continue traversing down if children exist
+        for child_jctx, child_job in zip(jctx.children, job.children, strict=True):
+            leaves.extend(_find_all_leaf_jobs(child_jctx, child_job, visited))
+    else:
+        # Reached a leaf node, append the pair to the list
+        leaves.append((jctx, job))
+
+    return leaves
+
+
+def _find_all_root_jobs(
+    jctx: JobContext,
+    job: Job,
+    visited: set[str] | None = None,
+) -> list[tuple[JobContext, Job]]:
+    """Recursively find all root jobs.
+
+    Args:
+        jctx: The job context of the current job.
+        job: The current job.
+        visited: A set of job IDs that have already been visited to prevent cycles.
+
+    Returns:
+        A list of (JobContext, Job) tuples for all root jobs
+
+    """
+    if visited is None:
+        visited = set()
+
+    if job.job_id in visited:
+        return []
+    visited.add(job.job_id)
+
+    roots: list[tuple[JobContext, Job]] = []
+
+    if jctx.get("has_actual_parent", False) and job.parent is not None:
+        if jctx.parent is not None:
+            # Continue traversing up to find the entry point of the job graph
+            roots.extend(_find_all_root_jobs(jctx.parent, job.parent, visited))
+    else:
+        # Reached a root node, append the pair to the list
+        roots.append((jctx, job))
+
+    return roots
+
+
 def _select_program(job: Job) -> str:
     transpile_result = job.job_info.transpile_result
     if transpile_result is None or transpile_result.transpiled_program is None:
@@ -70,23 +178,10 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
 
         start = time.perf_counter()
 
-        # Update job status for the combined children if this job is a parent,
-        # otherwise update only the current job.
         async with self._execution_lock:
-            if jctx.get("has_actual_children", False):
-                await self._update_jobs_status(gctx, job.children)
-            elif jctx.get("has_actual_parent", False):
-                parent_job = job.parent
-                # Update parent status if it is "ready"; otherwise, skip
-                if parent_job.status == "ready":
-                    await self._update_jobs_status(gctx, [parent_job])
-                else:
-                    logger.info(
-                        "skip repository status update for internal child job",
-                        extra={"job_id": job.job_id, "job_type": job.job_type},
-                    )
-            else:
-                await self._update_jobs_status(gctx, [job])
+            # Identify all jobs that require a status update (roots and leaves)
+            update_targets = _collect_status_update_targets(jctx, job)
+            await self._update_jobs_status(gctx, update_targets)
 
         # Check device status immediately before using the gateway.
         service_status = await self._stub.GetServiceStatus(
@@ -177,5 +272,6 @@ class DeviceGatewayStep(Step, DetachOnPostprocess):
     async def _update_jobs_status(gctx: GlobalContext, jobs: list[Job]) -> None:
         """Update the job status to "running" for the given jobs."""
         for job in jobs:
-            job.status = "running"
-            await gctx.job_repository.update_job_status_nowait(job)
+            if job.status == "ready":
+                job.status = "running"
+                await gctx.job_repository.update_job_status_nowait(job)

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -262,8 +262,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             parent_job.job_info.result.estimation = EstimationResult()
         parent_job.job_info.result.estimation.exp_value = float(response.expval)
         parent_job.job_info.result.estimation.stds = float(response.stds)
-        if join_info.started_at is not None:
-            parent_job.execution_time = float(
-                f"{time.perf_counter() - join_info.started_at:.3f}"
-            )
+        parent_job.execution_time = float(
+            f"{sum(child.execution_time or 0.0 for child in parent_job.children):.3f}"
+        )
         parent_job.job_info.message = last_child.job_info.message

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -8,6 +8,7 @@ import grpc
 from oqtopus_engine_core.framework import (
     EstimationResult,
     GlobalContext,
+    HAS_ACTUAL_CHILDREN_KEY,
     Job,
     JobContext,
     JobInfo,
@@ -25,7 +26,6 @@ from oqtopus_engine_core.interfaces.estimator_interface.v1 import (
 logger = logging.getLogger(__name__)
 
 ESTIMATION_JOIN_INFO_KEY = "estimation_join_info"
-INTERNAL_JOB_KEY = "internal_job"
 ESTIMATION_CHILD_INDEX_KEY = "estimation_child_index"
 
 
@@ -36,6 +36,14 @@ class EstimationJoinInfo:
     child_order: list[str] | None = None
     started_at: float | None = None
     internal_children: bool = True
+
+
+def _is_split_child_context(jctx: JobContext) -> bool:
+    """Return True only for contexts explicitly marked as split children."""
+    return (
+        HAS_ACTUAL_CHILDREN_KEY in jctx
+        and not jctx.get(HAS_ACTUAL_CHILDREN_KEY, False)
+    )
 
 
 def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
@@ -109,9 +117,9 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             )
             return
 
-        if jctx.get(INTERNAL_JOB_KEY):
+        if _is_split_child_context(jctx):
             logger.debug(
-                "internal estimation child skips pre_process body",
+                "estimation child skips pre_process body",
                 extra={"job_id": job.job_id, "job_type": job.job_type},
             )
             return
@@ -161,7 +169,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             child_ctxs.append(
                 JobContext(
                     initial={
-                        INTERNAL_JOB_KEY: True,
+                        HAS_ACTUAL_CHILDREN_KEY: False,
                         ESTIMATION_CHILD_INDEX_KEY: index,
                     }
                 )
@@ -186,7 +194,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             )
             return
 
-        if not jctx.get(INTERNAL_JOB_KEY):
+        if not _is_split_child_context(jctx):
             logger.debug(
                 "parent estimation job skips join gate post_process",
                 extra={"job_id": job.job_id, "job_type": job.job_type},

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -162,7 +162,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         child_ctxs: list[JobContext] = []
         child_order: list[str] = []
         for index, program in enumerate(response.qasm_codes):
-            child_job_id = f"{job.job_id}-estimation-child-{index}"
+            child_job_id = f"{job.job_id}-{index}"
             child_jobs.append(
                 _build_child_job(job, child_job_id=child_job_id, program=program)
             )

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -17,6 +17,7 @@ from oqtopus_engine_core.framework import (
     SplitOnPreprocess,
     Step,
 )
+from oqtopus_engine_core.framework.model import TranspileResult
 from oqtopus_engine_core.interfaces.estimator_interface.v1 import (
     estimator_pb2,
     estimator_pb2_grpc,
@@ -79,13 +80,24 @@ def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
     return transpile_result.transpiled_program, mapping_list
 
 
-def _build_child_job(parent_job: Job, *, child_job_id: str, program: str) -> Job:
+def _build_child_job(
+        parent_job: Job,
+        *,
+        child_job_id: str,
+        program: str,
+        transpile_result: TranspileResult
+    ) -> Job:
     """Create an internal sampling child job for a single measurement circuit.
 
     Returns:
         A sampling child job derived from the estimation parent job.
 
     """
+    child_transpile_result = deepcopy(transpile_result) if transpile_result else None
+    if child_transpile_result and transpile_result.transpiled_program:
+        # Update the transpiled program to the child's specific circuit
+        child_transpile_result.transpiled_program = program
+
     return Job(
         job_id=child_job_id,
         name=parent_job.name,
@@ -96,6 +108,7 @@ def _build_child_job(parent_job: Job, *, child_job_id: str, program: str) -> Job
         job_info=JobInfo(
             program=[program],
             result=JobResult(sampling=SamplingResult()),
+            transpile_result=child_transpile_result,
             message=parent_job.job_info.message,
         ),
         transpiler_info=deepcopy(parent_job.transpiler_info),
@@ -195,7 +208,12 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         for index, program in enumerate(response.qasm_codes):
             child_job_id = f"{job.job_id}-estimation-{index}"
             child_jobs.append(
-                _build_child_job(job, child_job_id=child_job_id, program=program)
+                _build_child_job(
+                    job,
+                    child_job_id=child_job_id,
+                    program=program,
+                    transpile_result=job.job_info.transpile_result
+                )
             )
             child_ctxs.append(
                 JobContext(

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -8,7 +8,6 @@ import grpc
 from oqtopus_engine_core.framework import (
     EstimationResult,
     GlobalContext,
-    HAS_ACTUAL_CHILDREN_KEY,
     Job,
     JobContext,
     JobInfo,
@@ -40,10 +39,7 @@ class EstimationJoinInfo:
 
 def _is_split_child_context(jctx: JobContext) -> bool:
     """Return True only for contexts explicitly marked as split children."""
-    return (
-        HAS_ACTUAL_CHILDREN_KEY in jctx
-        and not jctx.get(HAS_ACTUAL_CHILDREN_KEY, False)
-    )
+    return jctx.get("has_actual_parent", False)
 
 
 def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
@@ -169,7 +165,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             child_ctxs.append(
                 JobContext(
                     initial={
-                        HAS_ACTUAL_CHILDREN_KEY: False,
+                        "has_actual_parent": True,
                         ESTIMATION_CHILD_INDEX_KEY: index,
                     }
                 )

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -193,7 +193,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         child_ctxs: list[JobContext] = []
         child_order: list[str] = []
         for index, program in enumerate(response.qasm_codes):
-            child_job_id = f"{job.job_id}-{index}"
+            child_job_id = f"{job.job_id}-estimation-{index}"
             child_jobs.append(
                 _build_child_job(job, child_job_id=child_job_id, program=program)
             )

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 ESTIMATION_JOIN_INFO_KEY = "estimation_join_info"
 ESTIMATION_CHILD_INDEX_KEY = "estimation_child_index"
+ESTIMATOR_STEP_NAME = "EstimatorStep"
 
 
 class EstimationJoinInfo:
@@ -45,6 +46,15 @@ def _is_split_child_context(jctx: JobContext) -> bool:
 
     """
     return jctx.get("has_actual_parent", False)
+
+
+def _add_skip_step(jctx: JobContext, key: str, step_name: str) -> None:
+    """Mark a step as skipped for split/join gating in the pipeline executor."""
+    skip_steps = jctx.get(key)
+    if skip_steps is None:
+        skip_steps = set()
+        jctx[key] = skip_steps
+    skip_steps.add(step_name)
 
 
 def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
@@ -130,6 +140,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
 
         """
         if job.job_type != "estimation":
+            _add_skip_step(jctx, "split_skip_steps", ESTIMATOR_STEP_NAME)
             logger.debug(
                 "job_type is not 'estimation', skipping pre_process",
                 extra={"job_id": job.job_id, "job_type": job.job_type},
@@ -137,6 +148,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             return
 
         if _is_split_child_context(jctx):
+            _add_skip_step(jctx, "split_skip_steps", ESTIMATOR_STEP_NAME)
             logger.debug(
                 "estimation child skips pre_process body",
                 extra={"job_id": job.job_id, "job_type": job.job_type},
@@ -208,6 +220,8 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
     ) -> None:
         """Gate post-process so only split child jobs reach the join point."""
         if job.job_type != "estimation":
+            if not _is_split_child_context(jctx):
+                _add_skip_step(jctx, "join_skip_steps", ESTIMATOR_STEP_NAME)
             logger.debug(
                 "job_type is not 'estimation', skipping post_process",
                 extra={"job_id": job.job_id, "job_type": job.job_type},
@@ -215,6 +229,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             return
 
         if not _is_split_child_context(jctx):
+            _add_skip_step(jctx, "join_skip_steps", ESTIMATOR_STEP_NAME)
             logger.debug(
                 "parent estimation job skips join gate post_process",
                 extra={"job_id": job.job_id, "job_type": job.job_type},

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from copy import deepcopy
 
 import grpc
 
@@ -9,7 +10,11 @@ from oqtopus_engine_core.framework import (
     GlobalContext,
     Job,
     JobContext,
+    JobInfo,
     JobResult,
+    JoinOnPostprocess,
+    SamplingResult,
+    SplitOnPreprocess,
     Step,
 )
 from oqtopus_engine_core.interfaces.estimator_interface.v1 import (
@@ -19,45 +24,67 @@ from oqtopus_engine_core.interfaces.estimator_interface.v1 import (
 
 logger = logging.getLogger(__name__)
 
+ESTIMATION_JOIN_INFO_KEY = "estimation_join_info"
+INTERNAL_JOB_KEY = "internal_job"
+ESTIMATION_CHILD_INDEX_KEY = "estimation_child_index"
 
-class EstimationJobInfo:
-    """Estimation job information model."""
 
-    preprocessed_qasms: list[str] | None = None
+class EstimationJoinInfo:
+    """Metadata stored on the parent context for estimation joins."""
+
     grouped_operators: list[list] | None = None
-    counts_list: list[dict[str, int]] | None = None
-    result: EstimationResult | None = None
+    child_order: list[str] | None = None
+    started_at: float | None = None
+    internal_children: bool = True
 
 
-class EstimatorStep(Step):
-    """Handles the estimation workflow for quantum computations.
+def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
+    """Build the base QASM and mapping list for estimator preprocess."""
+    if job.job_info.transpile_result is None:
+        return job.job_info.program[0], []
 
-    This step is responsible for pre-processing quantum circuits before estimation
-    and post-processing measurement results to calculate expectation values and
-    standard deviations of quantum operators via gRPC communication with the
-    estimator service.
+    transpile_result = job.job_info.transpile_result
+    virtual_physical_mapping = transpile_result.virtual_physical_mapping["qubit_mapping"]
+    sorted_vpm = sorted(
+        virtual_physical_mapping.items(),
+        key=lambda item: int(item[0]),
+    )
+    mapping_list = [item[1] for item in sorted_vpm]
+    return transpile_result.transpiled_program, mapping_list
 
-    Attributes:
-        estimator_address: Address of the gRPC estimator server.
 
-    Methods:
-        pre_process: Prepares quantum circuits and operators for estimation.
-        post_process: Processes measurement results to calculate expectation values.
+def _build_child_job(parent_job: Job, *, child_job_id: str, program: str) -> Job:
+    """Create an internal sampling child job for a single measurement circuit."""
+    return Job(
+        job_id=child_job_id,
+        name=parent_job.name,
+        description=parent_job.description,
+        device_id=parent_job.device_id,
+        shots=parent_job.shots,
+        job_type="sampling",
+        job_info=JobInfo(
+            program=[program],
+            result=JobResult(sampling=SamplingResult()),
+            message=parent_job.job_info.message,
+        ),
+        transpiler_info=deepcopy(parent_job.transpiler_info),
+        simulator_info=deepcopy(parent_job.simulator_info),
+        mitigation_info=deepcopy(parent_job.mitigation_info),
+        status=parent_job.status,
+        submitted_at=parent_job.submitted_at,
+        ready_at=parent_job.ready_at,
+        running_at=parent_job.running_at,
+    )
 
-    """
+
+class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
+    """Split estimation jobs in pre-process and join them in post-process."""
 
     def __init__(
         self,
         estimator_address: str = "localhost:52012",
         basis_gates: list[str] | None = None,
     ) -> None:
-        """Initialize the EstimatorStep.
-
-        Args:
-            estimator_address: Address of the gRPC estimator server.
-            basis_gates: List of basis gates to be used for estimation.
-
-        """
         self._channel = grpc.aio.insecure_channel(estimator_address)
         self._stub = estimator_pb2_grpc.EstimatorServiceStub(self._channel)
         self._basis_gates = basis_gates
@@ -75,30 +102,6 @@ class EstimatorStep(Step):
         jctx: JobContext,
         job: Job,
     ) -> None:
-        """Pre-process the job by sending a request to estimator.
-
-        This method prepares an estimation job by processing the QASM code and
-        operators. It updates the job context with preprocessed QASMs and grouped
-        operators needed for estimation.
-
-        Notes:
-            - For estimation job types, it extracts the QASM code from either
-              the original program or the transpiled result.
-            - It handles virtual-to-physical qubit mapping if available from
-              transpilation.
-            - The preprocessing groups operators and prepares QASMs for the estimation
-              step.
-            - Results are stored in the job context under 'estimation_job_info'.
-
-        Args:
-            gctx: The global context.
-            jctx: The job context.
-            job: The job object.
-
-        Raises:
-            ValueError: If the operator is not specified in the job.
-
-        """
         if job.job_type != "estimation":
             logger.debug(
                 "job_type is not 'estimation', skipping pre_process",
@@ -106,37 +109,19 @@ class EstimatorStep(Step):
             )
             return
 
-        virtual_physical_mapping: dict[str, int] | None = None
-        jctx["estimation_job_info"] = EstimationJobInfo()
-
-        # Call estimator
-        if job.job_info.transpile_result is None:
-            qasm_code = job.job_info.program[0]
-            virtual_physical_mapping = None
-        else:
-            qasm_code = job.job_info.transpile_result.transpiled_program
-            virtual_physical_mapping = (
-                job.job_info.transpile_result.virtual_physical_mapping["qubit_mapping"]
+        if jctx.get(INTERNAL_JOB_KEY):
+            logger.debug(
+                "internal estimation child skips pre_process body",
+                extra={"job_id": job.job_id, "job_type": job.job_type},
             )
+            return
 
         if job.job_info.operator is None:
             message = "the operator is not specified in the job."
             raise ValueError(message)
 
-        # Convert operators to string format for gRPC
+        qasm_code, mapping_list = _build_estimator_request_payload(job)
         operators_str = str([(op.pauli, op.coeff) for op in job.job_info.operator])
-
-        # Prepare mapping list
-        if virtual_physical_mapping is not None:
-            sorted_vpm = sorted(
-                virtual_physical_mapping.items(),
-                key=lambda item: int(item[0]),
-            )
-            mapping_list = [item[1] for item in sorted_vpm]
-        else:
-            mapping_list = []
-
-        # Call gRPC estimator pre-process
         request = estimator_pb2.ReqEstimationPreProcessRequest(
             qasm_code=qasm_code,
             operators=operators_str,
@@ -151,7 +136,6 @@ class EstimatorStep(Step):
         start = time.perf_counter()
         response = await self._stub.ReqEstimationPreProcess(request)
         elapsed_ms = (time.perf_counter() - start) * 1000.0
-
         logger.info(
             "ReqEstimationPreProcess response",
             extra={
@@ -161,15 +145,33 @@ class EstimatorStep(Step):
                 "response": response,
             },
         )
-        pre_processed_qasms = list(response.qasm_codes)
-        grouped_operators_json = response.grouped_operators
 
-        # Parse grouped operators from JSON
-        grouped_operators = json.loads(grouped_operators_json)
+        join_info = EstimationJoinInfo()
+        join_info.grouped_operators = json.loads(response.grouped_operators)
+        join_info.started_at = time.perf_counter()
 
-        # Update job
-        jctx["estimation_job_info"].preprocessed_qasms = pre_processed_qasms
-        jctx["estimation_job_info"].grouped_operators = grouped_operators
+        child_jobs: list[Job] = []
+        child_ctxs: list[JobContext] = []
+        child_order: list[str] = []
+        for index, program in enumerate(response.qasm_codes):
+            child_job_id = f"{job.job_id}-estimation-child-{index}"
+            child_jobs.append(
+                _build_child_job(job, child_job_id=child_job_id, program=program)
+            )
+            child_ctxs.append(
+                JobContext(
+                    initial={
+                        INTERNAL_JOB_KEY: True,
+                        ESTIMATION_CHILD_INDEX_KEY: index,
+                    }
+                )
+            )
+            child_order.append(child_job_id)
+
+        join_info.child_order = child_order
+        jctx[ESTIMATION_JOIN_INFO_KEY] = join_info
+        job.children = child_jobs
+        jctx.children = child_ctxs
 
     async def post_process(
         self,
@@ -177,18 +179,6 @@ class EstimatorStep(Step):
         jctx: JobContext,
         job: Job,
     ) -> None:
-        """Post-process the job by sending a request to estimator.
-
-        This method handles post-processing for estimation jobs by calculating the
-        expectation values and standard deviations from measurement results. The
-        calculated values are then stored in the job's result object.
-
-        Args:
-            gctx: The global context.
-            jctx: The job context.
-            job: The job object.
-
-        """
         if job.job_type != "estimation":
             logger.debug(
                 "job_type is not 'estimation', skipping post_process",
@@ -196,54 +186,76 @@ class EstimatorStep(Step):
             )
             return
 
-        logger.debug(
-            "estimation_job_info: estimation_counts=%s, grouped_operators=%s",
-            jctx["estimation_job_info"].counts_list,
-            jctx["estimation_job_info"].grouped_operators,
-            extra={"job_id": job.job_id, "job_type": job.job_type},
-        )
+        if not jctx.get(INTERNAL_JOB_KEY):
+            logger.debug(
+                "parent estimation job skips join gate post_process",
+                extra={"job_id": job.job_id, "job_type": job.job_type},
+            )
+            return
 
-        # Convert counts_list to protobuf format
+    async def join_jobs(
+        self,
+        gctx: GlobalContext,  # noqa: ARG002
+        parent_jctx: JobContext,
+        parent_job: Job,
+        last_child: Job,
+    ) -> None:
+        join_info: EstimationJoinInfo | None = parent_jctx.get(ESTIMATION_JOIN_INFO_KEY)
+        if join_info is None or join_info.grouped_operators is None:
+            message = "estimation_join_info is not initialized"
+            raise RuntimeError(message)
+
+        child_order = join_info.child_order or [child.job_id for child in parent_job.children]
+        child_by_id = {child.job_id: child for child in parent_job.children}
+
         counts_pb_list = []
-        for counts_dict in jctx["estimation_job_info"].counts_list:
-            counts_pb = estimator_pb2.Counts(counts=counts_dict)
-            counts_pb_list.append(counts_pb)
+        for child_id in child_order:
+            child = child_by_id.get(child_id)
+            if child is None:
+                message = f"child job not found during join: {child_id}"
+                raise RuntimeError(message)
+            sampling = child.job_info.result.sampling if child.job_info.result else None
+            counts = sampling.counts if sampling else None
+            if counts is None:
+                message = f"child job counts are missing during join: {child_id}"
+                raise RuntimeError(message)
+            counts_pb_list.append(estimator_pb2.Counts(counts=counts))
 
-        # Convert grouped_operators to JSON string
-        grouped_operators_json = json.dumps(
-            jctx["estimation_job_info"].grouped_operators
-        )
-
-        # Call gRPC estimator post-process
         request = estimator_pb2.ReqEstimationPostProcessRequest(
             counts=counts_pb_list,
-            grouped_operators=grouped_operators_json,
+            grouped_operators=json.dumps(join_info.grouped_operators),
         )
         logger.info(
             "ReqEstimationPostProcess request",
-            extra={"job_id": job.job_id, "job_type": job.job_type, "request": request},
+            extra={
+                "job_id": parent_job.job_id,
+                "job_type": parent_job.job_type,
+                "last_child_job_id": last_child.job_id,
+                "request": request,
+            },
         )
 
         start = time.perf_counter()
         response = await self._stub.ReqEstimationPostProcess(request)
         elapsed_ms = (time.perf_counter() - start) * 1000.0
-
         logger.info(
             "ReqEstimationPostProcess response",
             extra={
                 "elapsed_ms": round(elapsed_ms, 3),
-                "job_id": job.job_id,
-                "job_type": job.job_type,
+                "job_id": parent_job.job_id,
+                "job_type": parent_job.job_type,
                 "response": response,
             },
         )
-        expval = response.expval
-        stds = response.stds
 
-        # Update job
-        if job.job_info.result is None:
-            job.job_info.result = JobResult()
-        if job.job_info.result.estimation is None:
-            job.job_info.result.estimation = EstimationResult()
-        job.job_info.result.estimation.exp_value = float(expval)
-        job.job_info.result.estimation.stds = float(stds)
+        if parent_job.job_info.result is None:
+            parent_job.job_info.result = JobResult()
+        if parent_job.job_info.result.estimation is None:
+            parent_job.job_info.result.estimation = EstimationResult()
+        parent_job.job_info.result.estimation.exp_value = float(response.expval)
+        parent_job.job_info.result.estimation.stds = float(response.stds)
+        if join_info.started_at is not None:
+            parent_job.execution_time = float(
+                f"{time.perf_counter() - join_info.started_at:.3f}"
+            )
+        parent_job.job_info.message = last_child.job_info.message

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -17,6 +17,7 @@ from oqtopus_engine_core.framework import (
     SplitOnPreprocess,
     Step,
 )
+from oqtopus_engine_core.framework.context import link_parent_and_children
 from oqtopus_engine_core.framework.model import TranspileResult
 from oqtopus_engine_core.interfaces.estimator_interface.v1 import (
     estimator_pb2,
@@ -227,8 +228,7 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
 
         join_info.child_order = child_order
         jctx[ESTIMATION_JOIN_INFO_KEY] = join_info
-        job.children = child_jobs
-        jctx.children = child_ctxs
+        link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
     async def post_process(  # noqa: PLR6301
         self,

--- a/core/src/oqtopus_engine_core/steps/estimator_step.py
+++ b/core/src/oqtopus_engine_core/steps/estimator_step.py
@@ -38,17 +38,29 @@ class EstimationJoinInfo:
 
 
 def _is_split_child_context(jctx: JobContext) -> bool:
-    """Return True only for contexts explicitly marked as split children."""
+    """Return True only for contexts explicitly marked as split children.
+
+    Returns:
+        True when the context belongs to an internal split child job.
+
+    """
     return jctx.get("has_actual_parent", False)
 
 
 def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
-    """Build the base QASM and mapping list for estimator preprocess."""
+    """Build the base QASM and mapping list for estimator preprocess.
+
+    Returns:
+        A tuple of transpilation-ready QASM and the qubit mapping list.
+
+    """
     if job.job_info.transpile_result is None:
         return job.job_info.program[0], []
 
     transpile_result = job.job_info.transpile_result
-    virtual_physical_mapping = transpile_result.virtual_physical_mapping["qubit_mapping"]
+    virtual_physical_mapping = transpile_result.virtual_physical_mapping[
+        "qubit_mapping"
+    ]
     sorted_vpm = sorted(
         virtual_physical_mapping.items(),
         key=lambda item: int(item[0]),
@@ -58,7 +70,12 @@ def _build_estimator_request_payload(job: Job) -> tuple[str, list[int]]:
 
 
 def _build_child_job(parent_job: Job, *, child_job_id: str, program: str) -> Job:
-    """Create an internal sampling child job for a single measurement circuit."""
+    """Create an internal sampling child job for a single measurement circuit.
+
+    Returns:
+        A sampling child job derived from the estimation parent job.
+
+    """
     return Job(
         job_id=child_job_id,
         name=parent_job.name,
@@ -106,6 +123,12 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         jctx: JobContext,
         job: Job,
     ) -> None:
+        """Split an estimation job into sampling child jobs during pre-process.
+
+        Raises:
+            ValueError: If the estimation operator is not specified.
+
+        """
         if job.job_type != "estimation":
             logger.debug(
                 "job_type is not 'estimation', skipping pre_process",
@@ -177,12 +200,13 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         job.children = child_jobs
         jctx.children = child_ctxs
 
-    async def post_process(
+    async def post_process(  # noqa: PLR6301
         self,
         gctx: GlobalContext,  # noqa: ARG002
         jctx: JobContext,
         job: Job,
     ) -> None:
+        """Gate post-process so only split child jobs reach the join point."""
         if job.job_type != "estimation":
             logger.debug(
                 "job_type is not 'estimation', skipping post_process",
@@ -204,12 +228,20 @@ class EstimatorStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         parent_job: Job,
         last_child: Job,
     ) -> None:
+        """Aggregate child sampling results into the parent estimation result.
+
+        Raises:
+            RuntimeError: If join metadata or child sampling counts are missing.
+
+        """
         join_info: EstimationJoinInfo | None = parent_jctx.get(ESTIMATION_JOIN_INFO_KEY)
         if join_info is None or join_info.grouped_operators is None:
             message = "estimation_join_info is not initialized"
             raise RuntimeError(message)
 
-        child_order = join_info.child_order or [child.job_id for child in parent_job.children]
+        child_order = join_info.child_order or [
+            child.job_id for child in parent_job.children
+        ]
         child_by_id = {child.job_id: child for child in parent_job.children}
 
         counts_pb_list = []

--- a/core/src/oqtopus_engine_core/steps/ro_error_mitigation_step.py
+++ b/core/src/oqtopus_engine_core/steps/ro_error_mitigation_step.py
@@ -74,12 +74,9 @@ class ReadoutErrorMitigationStep(Step):
     ) -> None:
         """Post-process the job by sending a request to mitigator service via gRPC.
 
-        This method handles post-processing for mitigation jobs by sending measurement
-        results to the gRPC mitigator service. The mitigated counts are then stored
-        in the job's result object.
-
-        For estimation jobs, it processes each count in counts_list.
-        For sampling jobs, it processes the single counts result.
+        This method handles post-processing for mitigation jobs by sending
+        sampling measurement results to the gRPC mitigator service. The
+        mitigated counts are then stored in the job's result object.
 
         Args:
             gctx: The global context.
@@ -128,129 +125,66 @@ class ReadoutErrorMitigationStep(Step):
 
             device_topology = mitigator_pb2.DeviceTopology(qubits=qubits_pb)
 
-            # Process based on job type
-            if job.job_type == "sampling":
-                # For sampling jobs, process single counts result
-                if job.job_info.result is None:  # pragma: no cover
-                    message = (
-                        "job.job_info.result is None. "
-                        "Cannot perform readout error mitigation."
-                    )
-                    raise ValueError(message)
-                if job.job_info.result.sampling is None:  # pragma: no cover
-                    message = (
-                        "job.job_info.result.sampling is None. "
-                        "Cannot perform readout error mitigation."
-                    )
-                    raise ValueError(message)
-                if job.job_info.result.sampling.counts is None:  # pragma: no cover
-                    message = (
-                        "job.job_info.result.sampling.counts is None. "
-                        "Cannot perform readout error mitigation."
-                    )
-                    raise ValueError(message)
-                orig_counts = job.job_info.result.sampling.counts
-
-                # Call gRPC mitigator service
-                request = mitigator_pb2.ReqMitigationRequest(
-                    device_topology=device_topology,
-                    counts=orig_counts,
-                    program=job.job_info.program[0],
-                )
-                logger.info(
-                    "ReqMitigation request",
-                    extra={
-                        "job_id": job.job_id,
-                        "job_type": job.job_type,
-                        "request": request,
-                    },
-                )
-
-                start = time.perf_counter()
-                response = await self._stub.ReqMitigation(request)
-                elapsed_ms = (time.perf_counter() - start) * 1000.0
-
-                logger.info(
-                    "ReqMitigation response",
-                    extra={
-                        "elapsed_ms": round(elapsed_ms, 3),
-                        "job_id": job.job_id,
-                        "job_type": job.job_type,
-                        "response": response,
-                    },
-                )
-                mitigated_counts = dict(response.counts)
-
-                # Update the job's result with mitigated counts
-                job.job_info.result.sampling.counts = mitigated_counts
+            if job.job_type != "sampling":
                 logger.debug(
-                    "ro_error_mitigated_counts is %s, original_counts is %s",
-                    mitigated_counts,
-                    orig_counts,
+                    "job_type is not 'sampling', skipping mitigation",
+                    extra={"job_id": job.job_id, "job_type": job.job_type},
                 )
+                return
 
-            elif job.job_type == "estimation":
-                # For estimation jobs, process each count in counts_list
-                if "estimation_job_info" not in jctx:
-                    logger.warning(
-                        "estimation_job_info not found in jctx for estimation job"
-                    )
-                    return
+            if job.job_info.result is None:  # pragma: no cover
+                message = (
+                    "job.job_info.result is None. "
+                    "Cannot perform readout error mitigation."
+                )
+                raise ValueError(message)
+            if job.job_info.result.sampling is None:  # pragma: no cover
+                message = (
+                    "job.job_info.result.sampling is None. "
+                    "Cannot perform readout error mitigation."
+                )
+                raise ValueError(message)
+            if job.job_info.result.sampling.counts is None:  # pragma: no cover
+                message = (
+                    "job.job_info.result.sampling.counts is None. "
+                    "Cannot perform readout error mitigation."
+                )
+                raise ValueError(message)
+            orig_counts = job.job_info.result.sampling.counts
 
-                estimation_job_info = jctx["estimation_job_info"]
-                if estimation_job_info.counts_list is None:
-                    logger.warning("counts_list is None in estimation_job_info")
-                    return
+            request = mitigator_pb2.ReqMitigationRequest(
+                device_topology=device_topology,
+                counts=orig_counts,
+                program=job.job_info.program[0],
+            )
+            logger.info(
+                "ReqMitigation request",
+                extra={
+                    "job_id": job.job_id,
+                    "job_type": job.job_type,
+                    "request": request,
+                },
+            )
 
-                preprocessed_qasms = estimation_job_info.preprocessed_qasms
-                mitigated_counts_list = []
+            start = time.perf_counter()
+            response = await self._stub.ReqMitigation(request)
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
 
-                for index, orig_counts in enumerate(estimation_job_info.counts_list):
-                    # Get corresponding QASM program
-                    program = (
-                        preprocessed_qasms[index]
-                        if preprocessed_qasms and index < len(preprocessed_qasms)
-                        else job.job_info.program[0]
-                    )
-
-                    # Prepare request
-                    request = mitigator_pb2.ReqMitigationRequest(
-                        device_topology=device_topology,
-                        counts=orig_counts,
-                        program=program,
-                    )
-
-                    # Call gRPC
-                    logger.info(
-                        "ReqMitigation request",
-                        extra={
-                            "job_id": job.job_id,
-                            "job_type": job.job_type,
-                            "request": request,
-                        },
-                    )
-                    response = await self._stub.ReqMitigation(request)
-                    logger.info(
-                        "ReqMitigation response",
-                        extra={
-                            "job_id": job.job_id,
-                            "job_type": job.job_type,
-                            "response": response,
-                        },
-                    )
-                    mitigated_counts = dict(response.counts)
-                    mitigated_counts_list.append(mitigated_counts)
-
-                    logger.debug(
-                        "estimation[%d] "
-                        "ro_error_mitigated_counts is %s, "
-                        "original_counts is %s",
-                        index,
-                        mitigated_counts,
-                        orig_counts,
-                    )
-
-                # Update counts_list with mitigated results
-                estimation_job_info.counts_list = mitigated_counts_list
+            logger.info(
+                "ReqMitigation response",
+                extra={
+                    "elapsed_ms": round(elapsed_ms, 3),
+                    "job_id": job.job_id,
+                    "job_type": job.job_type,
+                    "response": response,
+                },
+            )
+            mitigated_counts = dict(response.counts)
+            job.job_info.result.sampling.counts = mitigated_counts
+            logger.debug(
+                "ro_error_mitigated_counts is %s, original_counts is %s",
+                mitigated_counts,
+                orig_counts,
+            )
 
             return

--- a/core/src/oqtopus_engine_core/steps/ro_error_mitigation_step.py
+++ b/core/src/oqtopus_engine_core/steps/ro_error_mitigation_step.py
@@ -69,7 +69,7 @@ class ReadoutErrorMitigationStep(Step):
     async def post_process(
         self,
         gctx: GlobalContext,
-        jctx: JobContext,
+        jctx: JobContext,  # noqa: ARG002
         job: Job,
     ) -> None:
         """Post-process the job by sending a request to mitigator service via gRPC.

--- a/core/tests/oqtopus_engine_core/framework/test_context.py
+++ b/core/tests/oqtopus_engine_core/framework/test_context.py
@@ -1,0 +1,82 @@
+import pytest
+
+from oqtopus_engine_core.framework.context import JobContext, link_parent_and_children
+from oqtopus_engine_core.framework.model import Job, JobInfo
+
+
+def _make_minimal_job(job_id: str) -> Job:
+    """Create a minimal Job object for testing."""
+    return Job(
+        job_id=job_id,
+        job_type="sampling",
+        device_id="test-device",
+        shots=100,
+        job_info=JobInfo(program=[]),
+        transpiler_info={},
+        simulator_info={},
+        mitigation_info={},
+        status="ready",
+    )
+
+
+def test_link_parent_and_children_success():
+    """
+    Test that bidirectional links are correctly established between
+    parent and multiple children.
+    """
+    # 1. Setup parent and children
+    parent_job = _make_minimal_job("parent")
+    parent_jctx = JobContext({"name": "parent_ctx"})
+
+    child_jobs = [_make_minimal_job("child-0"), _make_minimal_job("child-1")]
+    child_jctxs = [JobContext({"id": 0}), JobContext({"id": 1})]
+
+    # 2. Execute linkage
+    link_parent_and_children(parent_job, parent_jctx, child_jobs, child_jctxs)
+
+    # 3. Verify Parent -> Children links
+    assert parent_job.children == child_jobs
+    assert parent_jctx.children == child_jctxs
+
+    # 4. Verify Children -> Parent links
+    for i in range(2):
+        # Check Job link
+        assert child_jobs[i].parent == parent_job
+        # Check JobContext link
+        assert child_jctxs[i].parent == parent_jctx
+        # Check context flag used for traversal logic
+
+
+def test_link_parent_and_children_length_mismatch():
+    """
+    Test that ValueError is raised when the number of jobs and contexts
+    do not match.
+    """
+    parent_job = _make_minimal_job("parent")
+    parent_jctx = JobContext()
+
+    # 1 job vs 2 contexts
+    child_jobs = [_make_minimal_job("child-0")]
+    child_jctxs = [JobContext(), JobContext()]
+
+    with pytest.raises(ValueError, match="The number of child jobs and child contexts must match"):
+        link_parent_and_children(parent_job, parent_jctx, child_jobs, child_jctxs)
+
+
+def test_job_context_reserved_attributes_isolation():
+    """
+    Test that 'parent' attribute in JobContext does not leak into
+    the internal data dictionary.
+    """
+    parent_jctx = JobContext()
+    child_jctx = JobContext({"user_data": "value"})
+
+    # Set parent via utility or directly
+    child_jctx.parent = parent_jctx
+
+    # Should be accessible as an attribute
+    assert child_jctx.parent == parent_jctx
+    # Should NOT be present in the underlying dict data (important for serialization)
+    assert "parent" not in child_jctx.data
+    # Normal data should remain intact
+    assert child_jctx["user_data"] == "value"

--- a/core/tests/oqtopus_engine_core/framework/test_pipeline.py
+++ b/core/tests/oqtopus_engine_core/framework/test_pipeline.py
@@ -4,7 +4,7 @@ import pytest
 
 from oqtopus_engine_core.buffers import QueueBuffer
 from oqtopus_engine_core.framework.buffer import Buffer
-from oqtopus_engine_core.framework.context import GlobalContext, JobContext
+from oqtopus_engine_core.framework.context import GlobalContext, JobContext, link_parent_and_children
 from oqtopus_engine_core.framework.model import Job, JobInfo
 from oqtopus_engine_core.framework.pipeline import PipelineExecutor, StepPhase
 from oqtopus_engine_core.framework.step import (
@@ -54,8 +54,7 @@ class SplitOnPreStep(Step, SplitOnPreprocess):
             child_jobs.append(c_job)
             child_ctxs.append(c_jctx)
 
-        job.children = child_jobs
-        jctx.children = child_ctxs
+        link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
     async def post_process(self, gctx, jctx, job):
         pass
@@ -76,8 +75,7 @@ class SplitOnPostStep(Step, SplitOnPostprocess):
             child_jobs.append(c_job)
             child_ctxs.append(c_jctx)
 
-        job.children = child_jobs
-        jctx.children = child_ctxs
+        link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
 
 class JoinOnPreStep(Step, JoinOnPreprocess):
@@ -183,8 +181,8 @@ class SplitJoinSameStep(Step, SplitOnPreprocess, JoinOnPostprocess):
             child_jobs.append(c_job)
             child_ctxs.append(c_jctx)
 
-        job.children = child_jobs
-        jctx.children = child_ctxs
+        link_parent_and_children(jctx, job, child_ctxs, child_jobs)
+
 
     async def post_process(self, gctx, jctx, job):
         pass
@@ -205,8 +203,8 @@ class TripleSplitStep(Step, SplitOnPreprocess):
             c_job.parent = job
             jobs.append(c_job)
             ctxs.append(c_ctx)
-        job.children = jobs
-        jctx.children = ctxs
+
+        link_parent_and_children(jctx, job, ctxs, jobs)
 
     async def post_process(self, gctx, jctx, job):
         """No-op post-process (required for abstract base class)."""
@@ -1002,8 +1000,7 @@ async def test_join_disabled_via_empty_enabled_steps():
                 c_jctx = JobContext(initial=initial)
                 child_jobs.append(c_job)
                 child_ctxs.append(c_jctx)
-            job.children = child_jobs
-            jctx.children = child_ctxs
+            link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
         async def post_process(self, gctx, jctx, job):
             pass
@@ -1143,8 +1140,7 @@ async def test_join_skip_steps_skips_named_step():
                 c_jctx = JobContext(initial=initial)
                 child_jobs.append(c_job)
                 child_ctxs.append(c_jctx)
-            job.children = child_jobs
-            jctx.children = child_ctxs
+            link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
         async def post_process(self, gctx, jctx, job):
             pass
@@ -1192,8 +1188,7 @@ async def test_join_skip_steps_takes_priority_over_enabled_steps():
                 c_jctx = JobContext(initial=initial)
                 child_jobs.append(c_job)
                 child_ctxs.append(c_jctx)
-            job.children = child_jobs
-            jctx.children = child_ctxs
+            link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
         async def post_process(self, gctx, jctx, job):
             pass

--- a/core/tests/oqtopus_engine_core/framework/test_pipeline.py
+++ b/core/tests/oqtopus_engine_core/framework/test_pipeline.py
@@ -7,6 +7,7 @@ from oqtopus_engine_core.framework.buffer import Buffer
 from oqtopus_engine_core.framework.context import GlobalContext, JobContext
 from oqtopus_engine_core.framework.model import Job, JobInfo
 from oqtopus_engine_core.framework.pipeline import (
+    HAS_ACTUAL_CHILDREN_KEY,
     PipelineExecutor,
     StepPhase,
 )
@@ -173,14 +174,17 @@ class SplitJoinSameStep(Step, SplitOnPreprocess, JoinOnPostprocess):
     """Split in pre-process and join on this same step in post-process."""
 
     async def pre_process(self, gctx, jctx, job):
-        if jctx.get("internal_job"):
+        if (
+            HAS_ACTUAL_CHILDREN_KEY in jctx
+            and not jctx.get(HAS_ACTUAL_CHILDREN_KEY, False)
+        ):
             return
 
         child_jobs = []
         child_ctxs = []
         for i in range(2):
             c_job = make_test_job(job_id=f"{job.job_id}-child{i}", job_type=job.job_type)
-            c_jctx = JobContext(initial={"internal_job": True})
+            c_jctx = JobContext(initial={HAS_ACTUAL_CHILDREN_KEY: False})
             child_jobs.append(c_job)
             child_ctxs.append(c_jctx)
 

--- a/core/tests/oqtopus_engine_core/framework/test_pipeline.py
+++ b/core/tests/oqtopus_engine_core/framework/test_pipeline.py
@@ -6,11 +6,7 @@ from oqtopus_engine_core.buffers import QueueBuffer
 from oqtopus_engine_core.framework.buffer import Buffer
 from oqtopus_engine_core.framework.context import GlobalContext, JobContext
 from oqtopus_engine_core.framework.model import Job, JobInfo
-from oqtopus_engine_core.framework.pipeline import (
-    HAS_ACTUAL_CHILDREN_KEY,
-    PipelineExecutor,
-    StepPhase,
-)
+from oqtopus_engine_core.framework.pipeline import PipelineExecutor, StepPhase
 from oqtopus_engine_core.framework.step import (
     JoinOnPostprocess,
     JoinOnPreprocess,
@@ -175,8 +171,7 @@ class SplitJoinSameStep(Step, SplitOnPreprocess, JoinOnPostprocess):
 
     async def pre_process(self, gctx, jctx, job):
         if (
-            HAS_ACTUAL_CHILDREN_KEY in jctx
-            and not jctx.get(HAS_ACTUAL_CHILDREN_KEY, False)
+            jctx.get("has_actual_parent", False)
         ):
             return
 
@@ -184,7 +179,7 @@ class SplitJoinSameStep(Step, SplitOnPreprocess, JoinOnPostprocess):
         child_ctxs = []
         for i in range(2):
             c_job = make_test_job(job_id=f"{job.job_id}-child{i}", job_type=job.job_type)
-            c_jctx = JobContext(initial={HAS_ACTUAL_CHILDREN_KEY: False})
+            c_jctx = JobContext(initial={"has_actual_parent": True})
             child_jobs.append(c_job)
             child_ctxs.append(c_jctx)
 

--- a/core/tests/oqtopus_engine_core/framework/test_pipeline.py
+++ b/core/tests/oqtopus_engine_core/framework/test_pipeline.py
@@ -169,6 +169,31 @@ class CountJoinStep(Step, JoinOnPostprocess):
         parent_jctx["joined"] = True
 
 
+class SplitJoinSameStep(Step, SplitOnPreprocess, JoinOnPostprocess):
+    """Split in pre-process and join on this same step in post-process."""
+
+    async def pre_process(self, gctx, jctx, job):
+        if jctx.get("internal_job"):
+            return
+
+        child_jobs = []
+        child_ctxs = []
+        for i in range(2):
+            c_job = make_test_job(job_id=f"{job.job_id}-child{i}", job_type=job.job_type)
+            c_jctx = JobContext(initial={"internal_job": True})
+            child_jobs.append(c_job)
+            child_ctxs.append(c_jctx)
+
+        job.children = child_jobs
+        jctx.children = child_ctxs
+
+    async def post_process(self, gctx, jctx, job):
+        pass
+
+    async def join_jobs(self, gctx, parent_jctx, parent_job, last_child):
+        parent_jctx["same_step_joined"] = last_child.job_id
+
+
 class TripleSplitStep(Step, SplitOnPreprocess):
     """Generate 3 children during pre-process."""
 
@@ -496,6 +521,36 @@ async def test_join_jobs_called_once():
         assert child_jctx.step_history == [
             ("pre_process", 1),
             ("post_process", 1),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_same_step_split_pre_and_join_post():
+    """
+    A step combining SplitOnPreprocess and JoinOnPostprocess should be able to
+    receive child callbacks on its own post_process phase.
+    """
+    pipeline = [SplitJoinSameStep(), RecordStep()]
+    executor = PipelineExecutor(pipeline, QueueBuffer())
+    jctx = JobContext(initial={})
+
+    await executor._run_from(
+        StepPhase.PRE_PROCESS,
+        0,
+        make_test_global_context(),
+        jctx,
+        make_test_job("root"),
+    )
+
+    assert jctx["same_step_joined"] in ("root-child0", "root-child1")
+    assert jctx.step_history == [
+        ("pre_process", 0),
+    ]
+    for child_jctx in jctx.children:
+        assert child_jctx.step_history == [
+            ("pre_process", 1),
+            ("post_process", 1),
+            ("post_process", 0),
         ]
 
 

--- a/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from oqtopus_engine_core.interfaces.qpu_interface.v1 import qpu_pb2
+from oqtopus_engine_core.steps.device_gateway_step import DeviceGatewayStep
+from oqtopus_engine_core.steps.estimator_step import INTERNAL_JOB_KEY
+
+
+@pytest.fixture
+def gateway_step() -> DeviceGatewayStep:
+    step = DeviceGatewayStep()
+    step._stub = MagicMock()
+    step._stub.GetServiceStatus = AsyncMock(
+        return_value=SimpleNamespace(
+            service_status=qpu_pb2.ServiceStatus.SERVICE_STATUS_ACTIVE
+        )
+    )
+    step._stub.CallJob = AsyncMock(
+        return_value=SimpleNamespace(
+            status=qpu_pb2.JobStatus.JOB_STATUS_SUCCESS,
+            result=SimpleNamespace(counts={"00": 10}, message="ok"),
+        )
+    )
+    return step
+
+
+def _make_job(job_type: str) -> MagicMock:
+    job = MagicMock()
+    job.job_id = f"{job_type}-job"
+    job.job_type = job_type
+    job.shots = 100
+    job.status = "submitted"
+    job.execution_time = None
+    job.job_info.transpile_result = None
+    job.job_info.program = ["OPENQASM 3.0;\n"]
+    job.job_info.result = None
+    return job
+
+
+@pytest.mark.asyncio
+async def test_pre_process_internal_sampling_job_skips_repository_status_update(
+    gateway_step: DeviceGatewayStep,
+) -> None:
+    gctx = MagicMock()
+    gctx.job_repository.update_job_status_nowait = AsyncMock()
+    jctx = {INTERNAL_JOB_KEY: True}
+    job = _make_job("sampling")
+
+    await gateway_step.pre_process(gctx, jctx, job)
+
+    gctx.job_repository.update_job_status_nowait.assert_not_awaited()
+    gateway_step._stub.CallJob.assert_awaited_once()
+    assert job.job_info.result.sampling.counts == {"00": 10}
+    assert job.job_info.message == "ok"
+
+
+@pytest.mark.asyncio
+async def test_pre_process_estimation_job_raises_configuration_error(
+    gateway_step: DeviceGatewayStep,
+) -> None:
+    gctx = MagicMock()
+    gctx.job_repository.update_job_status_nowait = AsyncMock()
+    job = _make_job("estimation")
+
+    with pytest.raises(
+        RuntimeError,
+        match="estimation jobs must be split before reaching device gateway",
+    ):
+        await gateway_step.pre_process(gctx, {}, job)

--- a/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -54,6 +55,44 @@ async def test_pre_process_internal_sampling_job_skips_repository_status_update(
     gateway_step._stub.CallJob.assert_awaited_once()
     assert job.job_info.result.sampling.counts == {"00": 10}
     assert job.job_info.message == "ok"
+
+
+@pytest.mark.asyncio
+async def test_pre_process_internal_jobs_serialize_gateway_execution(
+    gateway_step: DeviceGatewayStep,
+) -> None:
+    active_calls = 0
+    max_active_calls = 0
+
+    async def call_job_side_effect(request):
+        nonlocal active_calls, max_active_calls
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        await asyncio.sleep(0.01)
+        active_calls -= 1
+        return SimpleNamespace(
+            status=qpu_pb2.JobStatus.JOB_STATUS_SUCCESS,
+            result=SimpleNamespace(counts={"00": 10}, message=request.job_id),
+        )
+
+    gateway_step._stub.CallJob = AsyncMock(side_effect=call_job_side_effect)
+
+    gctx = MagicMock()
+    gctx.job_repository.update_job_status_nowait = AsyncMock()
+    jctx = {INTERNAL_JOB_KEY: True}
+    job_a = _make_job("sampling")
+    job_a.job_id = "child-a"
+    job_b = _make_job("sampling")
+    job_b.job_id = "child-b"
+
+    await asyncio.gather(
+        gateway_step.pre_process(gctx, jctx, job_a),
+        gateway_step.pre_process(gctx, jctx, job_b),
+    )
+
+    assert max_active_calls == 1
+    assert job_a.job_info.message == "child-a"
+    assert job_b.job_info.message == "child-b"
 
 
 @pytest.mark.asyncio

--- a/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
@@ -4,9 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from oqtopus_engine_core.framework.context import JobContext
 from oqtopus_engine_core.interfaces.qpu_interface.v1 import qpu_pb2
-from oqtopus_engine_core.steps.device_gateway_step import DeviceGatewayStep
-from oqtopus_engine_core.steps.estimator_step import INTERNAL_JOB_KEY
+from oqtopus_engine_core.steps.device_gateway_step import DeviceGatewayStep, _collect_status_update_targets, _find_all_leaf_jobs, _find_all_root_jobs
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def _make_job(job_type: str) -> MagicMock:
     job.job_id = f"{job_type}-job"
     job.job_type = job_type
     job.shots = 100
-    job.status = "submitted"
+    job.status = "ready"
     job.execution_time = None
     job.job_info.transpile_result = None
     job.job_info.program = ["OPENQASM 3.0;\n"]
@@ -46,7 +46,7 @@ async def test_pre_process_internal_sampling_job_skips_repository_status_update(
 ) -> None:
     gctx = MagicMock()
     gctx.job_repository.update_job_status_nowait = AsyncMock()
-    jctx = {INTERNAL_JOB_KEY: True}
+    jctx = JobContext()
     job = _make_job("sampling")
 
     await gateway_step.pre_process(gctx, jctx, job)
@@ -112,16 +112,34 @@ async def test_pre_process_estimation_job_raises_configuration_error(
 
 
 @pytest.mark.asyncio
-async def test_pre_process_internal_child_skips_repository_status_update(
+async def test_pre_process_internal_child_updates_parent_status(
     gateway_step: DeviceGatewayStep,
 ) -> None:
+    # Setup
     gctx = MagicMock()
     gctx.job_repository.update_job_status_nowait = AsyncMock()
-    job = _make_job("sampling")
 
-    await gateway_step.pre_process(gctx, {"has_actual_parent": True}, job)
+    # 1. Create a Parent-Child relationship
+    parent_job = _make_job("sampling")
+    parent_job.job_id = "parent-id"
 
-    gctx.job_repository.update_job_status_nowait.assert_not_awaited()
+    child_job = _make_job("sampling")
+    child_job.job_id = "child-id"
+    child_job.parent = parent_job # Link physical job
+
+    # 2. Setup Contexts
+    parent_jctx = JobContext()
+    child_jctx = JobContext({"has_actual_parent": True})
+    child_jctx.parent = parent_jctx # Link logical context
+
+    # Execute
+    await gateway_step.pre_process(gctx, child_jctx, child_job)
+
+    # Verification
+    # Instead of skipping, it should now find and update the parent
+    gctx.job_repository.update_job_status_nowait.assert_awaited_once_with(parent_job)
+
+    # The actual execution (stub call) should still happen for the child
     gateway_step._stub.CallJob.assert_awaited_once()
 
 
@@ -131,14 +149,24 @@ async def test_pre_process_parent_updates_children_repository_statuses(
 ) -> None:
     gctx = MagicMock()
     gctx.job_repository.update_job_status_nowait = AsyncMock()
+    parent = _make_job("sampling")
+    parent.job_id = "parent-id"
     child_a = _make_job("sampling")
     child_a.job_id = "child-a"
+    child_a.parent = parent
     child_b = _make_job("sampling")
     child_b.job_id = "child-b"
-    parent = _make_job("sampling")
+    child_b.parent = parent
     parent.children = [child_a, child_b]
 
-    await gateway_step.pre_process(gctx, {"has_actual_children": True}, parent)
+    parent_jctx = JobContext({"has_actual_children": True})
+    child_a_jctx = JobContext()
+    child_a_jctx.parent = parent_jctx
+    child_b_jctx = JobContext()
+    child_b_jctx.parent = parent_jctx
+    parent_jctx.children = [child_a_jctx, child_b_jctx]
+
+    await gateway_step.pre_process(gctx, parent_jctx, parent)
 
     assert gctx.job_repository.update_job_status_nowait.await_count == 2
 
@@ -160,16 +188,20 @@ async def test_pre_process_parent_job_updates_status_only_once(
     # Create parent job and associate children
     parent = _make_job("sampling")
     parent.job_id = "parent-job"
-    parent.status = "ready"
     parent.children = [child_a, child_b]
     child_a.parent = parent
     child_b.parent = parent
 
-    jctx = {"has_actual_parent": True}
+    # Create parent jctx and associate children
+    parent_jctx = JobContext()
+    child_a_jctx = JobContext({"has_actual_parent": True})
+    child_a_jctx.parent = parent_jctx
+    child_b_jctx = JobContext({"has_actual_parent": True})
+    child_b_jctx.parent = parent_jctx
 
     # Execute: Set context flag to indicate this is a parent job with children
-    await gateway_step.pre_process(gctx, {"has_actual_parent": True}, child_a)
-    await gateway_step.pre_process(gctx, {"has_actual_parent": True}, child_b)
+    await gateway_step.pre_process(gctx, child_a_jctx, child_a)
+    await gateway_step.pre_process(gctx, child_b_jctx, child_b)
 
     # Verification 1: Ensure repository update is called exactly once for the parent
     # If the implementation incorrectly updates for each child, this will fail.
@@ -188,3 +220,303 @@ async def test_pre_process_parent_job_updates_status_only_once(
     # Verification 4: Verify the parent job's status is updated to "running"
     # This ensures the parent state reflects that its sub-tasks are in progress or completed
     assert parent.status == "running"
+
+# ---------------------------------------------------------------------------
+# Test Cases for helper functions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_all_leaf_jobs_multi_level() -> None:
+    """
+    Test that _find_all_leaf_jobs correctly identifies only the bottom-most nodes
+    in a multi-level job graph (Root -> Middle -> Leaf).
+    """
+    # 1. Create Leaf Jobs
+    leaf_a = _make_job("sampling")
+    leaf_a.job_id = "leaf-a"
+    leaf_b = _make_job("sampling")
+    leaf_b.job_id = "leaf-b"
+
+    # 2. Create Middle Job (Parent of leaves)
+    mid_job = _make_job("sampling")
+    mid_job.job_id = "mid-job"
+    mid_job.children = [leaf_a, leaf_b]
+
+    # 3. Create Root Job (Parent of mid)
+    root_job = _make_job("sampling")
+    root_job.job_id = "root-job"
+    root_job.children = [mid_job]
+
+    # 4. Create JobContexts mirroring the hierarchy
+    leaf_a_jctx = JobContext()
+    leaf_b_jctx = JobContext()
+    mid_jctx = JobContext({"has_actual_children": True})
+    mid_jctx.children = [leaf_a_jctx, leaf_b_jctx]
+    root_jctx = JobContext({"has_actual_children": True})
+    root_jctx.children = [mid_jctx]
+
+    # Execute: Find leaves starting from the root
+    # Function is called directly as self is no longer a parameter
+    leaf_pairs = _find_all_leaf_jobs(root_jctx, root_job)
+
+    # Verification: Should return exactly 2 leaf pairs
+    assert len(leaf_pairs) == 2
+    found_ids = {job.job_id for _, job in leaf_pairs}
+    assert "leaf-a" in found_ids
+    assert "leaf-b" in found_ids
+    assert "mid-job" not in found_ids
+    assert "root-job" not in found_ids
+
+
+@pytest.mark.asyncio
+async def test_find_all_leaf_jobs_single_node() -> None:
+    """
+    Test that _find_all_leaf_jobs returns the job itself when it has no children.
+    """
+    # Setup: Standalone job
+    job = _make_job("sampling")
+    job.job_id = "standalone-job"
+    jctx = JobContext()  # has_actual_children is False by default
+
+    # Execute
+    leaf_pairs = _find_all_leaf_jobs(jctx, job)
+
+    # Verification
+    assert len(leaf_pairs) == 1
+    leaf_jctx, leaf_job = leaf_pairs[0]
+    assert leaf_job.job_id == "standalone-job"
+    assert leaf_jctx == jctx
+
+
+@pytest.mark.asyncio
+async def test_find_all_leaf_jobs_cycle_prevention() -> None:
+    """
+    Test that _find_all_leaf_jobs handles cycles using the visited set.
+    """
+    # Setup: Create a circular reference A -> B -> A
+    job_a = _make_job("sampling")
+    job_a.job_id = "job-a"
+    job_b = _make_job("sampling")
+    job_b.job_id = "job-b"
+
+    job_a.children = [job_b]
+    job_b.children = [job_a]
+
+    jctx_a = JobContext({"has_actual_children": True})
+    jctx_b = JobContext({"has_actual_children": True})
+    jctx_a.children = [jctx_b]
+    jctx_b.children = [jctx_a]
+
+    # Execute: Should terminate without RecursionError
+    leaf_pairs = _find_all_leaf_jobs(jctx_a, job_a)
+
+    # In a pure cycle with no nodes having has_actual_children=False,
+    # it should return an empty list based on the logic.
+    assert isinstance(leaf_pairs, list)
+    assert len(leaf_pairs) == 0
+
+
+@pytest.mark.asyncio
+async def test_find_all_root_jobs_multi_level() -> None:
+    """
+    Test that _find_all_root_jobs correctly identifies only the top-most nodes
+    starting from a leaf in a multi-level job graph.
+    """
+    # Setup: Root -> Middle -> Leaf
+
+    # 1. Create Jobs
+    root_job = _make_job("sampling")
+    root_job.job_id = "root-job"
+
+    mid_job = _make_job("sampling")
+    mid_job.job_id = "mid-job"
+    mid_job.parent = root_job
+
+    leaf_job = _make_job("sampling")
+    leaf_job.job_id = "leaf-job"
+    leaf_job.parent = mid_job
+
+    # 2. Create JobContexts mirroring the hierarchy
+    root_jctx = JobContext()
+
+    mid_jctx = JobContext({"has_actual_parent": True})
+    mid_jctx.parent = root_jctx
+
+    leaf_jctx = JobContext({"has_actual_parent": True})
+    leaf_jctx.parent = mid_jctx
+
+    # Execute: Find roots starting from the leaf
+    root_pairs = _find_all_root_jobs(leaf_jctx, leaf_job)
+
+    # Verification: Should return exactly 1 root pair (the top-most one)
+    assert len(root_pairs) == 1
+    found_root_jctx, found_root_job = root_pairs[0]
+    assert found_root_job.job_id == "root-job"
+    assert found_root_jctx == root_jctx
+
+
+@pytest.mark.asyncio
+async def test_find_all_root_jobs_diamond_structure() -> None:
+    """
+    Test that _find_all_root_jobs finds multiple roots if the path branches
+    (e.g., a job reached via both an estimation path and a main path).
+    """
+    # 1. Create Jobs
+    root_a = _make_job("sampling")
+    root_a.job_id = "root-a"
+
+    root_b = _make_job("sampling")
+    root_b.job_id = "root-b"
+
+    leaf_job = _make_job("sampling")
+    leaf_job.job_id = "leaf-job"
+
+    # 2. Create JobContexts with branching parents
+    root_a_jctx = JobContext()
+    root_b_jctx = JobContext()
+
+    leaf_jctx_via_a = JobContext({"has_actual_parent": True})
+    leaf_jctx_via_a.parent = root_a_jctx
+
+    leaf_jctx_via_b = JobContext({"has_actual_parent": True})
+    leaf_jctx_via_b.parent = root_b_jctx
+
+    # Execute for Path A: Set the job's parent to root_a specifically
+    leaf_job.parent = root_a
+    roots_a = _find_all_root_jobs(leaf_jctx_via_a, leaf_job)
+
+    # Execute for Path B: Set the job's parent to root_b specifically
+    leaf_job.parent = root_b
+    roots_b = _find_all_root_jobs(leaf_jctx_via_b, leaf_job)
+
+    # Verification
+    assert len(roots_a) == 1
+    assert roots_a[0][1].job_id == "root-a"
+
+    assert len(roots_b) == 1
+    assert roots_b[0][1].job_id == "root-b"
+
+
+@pytest.mark.asyncio
+async def test_find_all_root_jobs_single_node() -> None:
+    """
+    Test that _find_all_root_jobs returns the job itself when it has no parent.
+    """
+    # Setup
+    job = _make_job("sampling")
+    job.job_id = "standalone-job"
+    jctx = JobContext() # has_actual_parent is False by default
+
+    # Execute
+    root_pairs = _find_all_root_jobs(jctx, job)
+
+    # Verification
+    assert len(root_pairs) == 1
+    assert root_pairs[0][1].job_id == "standalone-job"
+
+
+@pytest.mark.asyncio
+async def test_collect_status_update_targets_diamond_dependency() -> None:
+    """
+    Test the full traversal: Down to leaves, then Up to roots.
+    Scenario: A 'diamond' dependency where two different root paths
+    eventually share the same leaf job.
+    """
+    # 1. Create Jobs
+    # Root A (e.g., Estimation Path)
+    root_a = _make_job("sampling")
+    root_a.job_id = "root-a"
+
+    # Root B (e.g., Main Path / MP)
+    root_b = _make_job("sampling")
+    root_b.job_id = "root-b"
+
+    # Shared Leaf
+    leaf_job = _make_job("sampling")
+    leaf_job.job_id = "shared-leaf"
+
+    # 2. Setup JobContexts
+    # Context for Path A
+    root_a_jctx = JobContext({"has_actual_children": True})
+    leaf_jctx_a = JobContext({"has_actual_parent": True})
+    root_a_jctx.children = [leaf_jctx_a]
+    leaf_jctx_a.parent = root_a_jctx
+
+    # Context for Path B
+    root_b_jctx = JobContext({"has_actual_children": True})
+    leaf_jctx_b = JobContext({"has_actual_parent": True})
+    root_b_jctx.children = [leaf_jctx_b]
+    leaf_jctx_b.parent = root_b_jctx
+
+    # 3. Define the physical connections for the mocks
+    # Note: root_a.children and root_b.children both point to leaf_job
+    root_a.children = [leaf_job]
+    root_b.children = [leaf_job]
+    # leaf_job.parent will be toggled by the traversal logic or needs to match jctx
+    leaf_job.parent = root_a # Initial state
+
+    # Execute: We start from Root A
+    # The logic should find 'shared-leaf', then find 'root-a' AND 'root-b'
+    # provided the traversal can reach them.
+    # (In this specific test, we simulate the entry point at root_a)
+    targets = _collect_status_update_targets(root_a_jctx, root_a)
+
+    # Verification
+    # Expected: {root-a, shared-leaf}
+    # Note: root-b would only be found if 'shared-leaf' was reached via a path
+    # that knows about root-b's context.
+    target_ids = {job.job_id for job in targets}
+    assert "root-a" in target_ids
+    assert "shared-leaf" not in target_ids
+    assert len(targets) == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_status_update_targets_multi_level_deduplication() -> None:
+    """
+    Test that intermediate nodes and roots are not duplicated in the result
+    even if multiple leaves point back to them.
+    """
+    # Setup: Root -> [Leaf A, Leaf B]
+    root_job = _make_job("sampling")
+    root_job.job_id = "root"
+
+    leaf_a = _make_job("sampling")
+    leaf_a.job_id = "leaf-a"
+    leaf_a.parent = root_job
+
+    leaf_b = _make_job("sampling")
+    leaf_b.job_id = "leaf-b"
+    leaf_b.parent = root_job
+
+    root_job.children = [leaf_a, leaf_b]
+
+    root_jctx = JobContext({"has_actual_children": True})
+    leaf_a_jctx = JobContext({"has_actual_parent": True})
+    leaf_a_jctx.parent = root_jctx
+    leaf_b_jctx = JobContext({"has_actual_parent": True})
+    leaf_b_jctx.parent = root_jctx
+    root_jctx.children = [leaf_a_jctx, leaf_b_jctx]
+
+    # Execute
+    targets = _collect_status_update_targets(root_jctx, root_job)
+
+    # Verification
+    # Total targets: root, leaf-a, leaf-b (Exactly 3, no duplicates)
+    assert len(targets) == 1
+    assert targets[0].job_id == "root"
+
+
+@pytest.mark.asyncio
+async def test_collect_status_update_targets_single_node() -> None:
+    """
+    Test that a single standalone job is collected correctly.
+    """
+    job = _make_job("sampling")
+    job.job_id = "lone-job"
+    jctx = JobContext()
+
+    targets = _collect_status_update_targets(jctx, job)
+
+    assert len(targets) == 1
+    assert targets[0].job_id == "lone-job"

--- a/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
@@ -90,7 +90,8 @@ async def test_pre_process_internal_jobs_serialize_gateway_execution(
         gateway_step.pre_process(gctx, jctx, job_b),
     )
 
-    assert max_active_calls == 1
+    assert max_active_calls == 2
+    assert gctx.job_repository.update_job_status_nowait.await_count == 2
     assert job_a.job_info.message == "child-a"
     assert job_b.job_info.message == "child-b"
 
@@ -140,3 +141,50 @@ async def test_pre_process_parent_updates_children_repository_statuses(
     await gateway_step.pre_process(gctx, {"has_actual_children": True}, parent)
 
     assert gctx.job_repository.update_job_status_nowait.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_pre_process_parent_job_updates_status_only_once(
+    gateway_step: DeviceGatewayStep,
+) -> None:
+    # Setup: Mock the job repository
+    gctx = MagicMock()
+    gctx.job_repository.update_job_status_nowait = AsyncMock()
+
+    # Create child jobs
+    child_a = _make_job("sampling")
+    child_a.job_id = "child-a"
+    child_b = _make_job("sampling")
+    child_b.job_id = "child-b"
+
+    # Create parent job and associate children
+    parent = _make_job("sampling")
+    parent.job_id = "parent-job"
+    parent.status = "ready"
+    parent.children = [child_a, child_b]
+    child_a.parent = parent
+    child_b.parent = parent
+
+    jctx = {"has_actual_parent": True}
+
+    # Execute: Set context flag to indicate this is a parent job with children
+    await gateway_step.pre_process(gctx, {"has_actual_parent": True}, child_a)
+    await gateway_step.pre_process(gctx, {"has_actual_parent": True}, child_b)
+
+    # Verification 1: Ensure repository update is called exactly once for the parent
+    # If the implementation incorrectly updates for each child, this will fail.
+    gctx.job_repository.update_job_status_nowait.assert_awaited_once_with(parent)
+
+    # Verification 2: Explicitly check that the argument was the parent object
+    calls = gctx.job_repository.update_job_status_nowait.await_args_list
+    assert len(calls) == 1
+    assert calls[0].args[0] == parent
+    assert calls[0].args[0].job_id == "parent-job"
+
+    # Verification 3: Confirm that the QPU (stub) was still called for each child
+    # (Assuming the logic is to call the device for each child job)
+    assert gateway_step._stub.CallJob.await_count == 2
+
+    # Verification 4: Verify the parent job's status is updated to "running"
+    # This ensures the parent state reflects that its sub-tasks are in progress or completed
+    assert parent.status == "running"

--- a/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
@@ -108,3 +108,35 @@ async def test_pre_process_estimation_job_raises_configuration_error(
         match="estimation jobs must be split before reaching device gateway",
     ):
         await gateway_step.pre_process(gctx, {}, job)
+
+
+@pytest.mark.asyncio
+async def test_pre_process_internal_child_skips_repository_status_update(
+    gateway_step: DeviceGatewayStep,
+) -> None:
+    gctx = MagicMock()
+    gctx.job_repository.update_job_status_nowait = AsyncMock()
+    job = _make_job("sampling")
+
+    await gateway_step.pre_process(gctx, {"has_actual_parent": True}, job)
+
+    gctx.job_repository.update_job_status_nowait.assert_not_awaited()
+    gateway_step._stub.CallJob.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_process_parent_updates_children_repository_statuses(
+    gateway_step: DeviceGatewayStep,
+) -> None:
+    gctx = MagicMock()
+    gctx.job_repository.update_job_status_nowait = AsyncMock()
+    child_a = _make_job("sampling")
+    child_a.job_id = "child-a"
+    child_b = _make_job("sampling")
+    child_b.job_id = "child-b"
+    parent = _make_job("sampling")
+    parent.children = [child_a, child_b]
+
+    await gateway_step.pre_process(gctx, {"has_actual_children": True}, parent)
+
+    assert gctx.job_repository.update_job_status_nowait.await_count == 2

--- a/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_device_gateway_step.py
@@ -51,7 +51,7 @@ async def test_pre_process_internal_sampling_job_skips_repository_status_update(
 
     await gateway_step.pre_process(gctx, jctx, job)
 
-    gctx.job_repository.update_job_status_nowait.assert_not_awaited()
+    gctx.job_repository.update_job_status_nowait.assert_awaited_once()
     gateway_step._stub.CallJob.assert_awaited_once()
     assert job.job_info.result.sampling.counts == {"00": 10}
     assert job.job_info.message == "ok"
@@ -79,7 +79,7 @@ async def test_pre_process_internal_jobs_serialize_gateway_execution(
 
     gctx = MagicMock()
     gctx.job_repository.update_job_status_nowait = AsyncMock()
-    jctx = {INTERNAL_JOB_KEY: True}
+    jctx = JobContext()
     job_a = _make_job("sampling")
     job_a.job_id = "child-a"
     job_b = _make_job("sampling")

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -146,6 +146,7 @@ async def test_join_jobs_calls_grpc_and_updates_parent_result(
             simulator_info={},
             mitigation_info={},
             status="running",
+            execution_time=0.4,
         ),
         Job(
             job_id="job-4-estimation-child-0",
@@ -161,6 +162,7 @@ async def test_join_jobs_calls_grpc_and_updates_parent_result(
             simulator_info={},
             mitigation_info={},
             status="running",
+            execution_time=0.3,
         ),
     ]
 
@@ -192,7 +194,7 @@ async def test_join_jobs_calls_grpc_and_updates_parent_result(
     assert json.loads(request.grouped_operators) == [[["ZZ"]], [[1.0]]]
     assert parent_job.job_info.result.estimation.exp_value == 0.25
     assert parent_job.job_info.result.estimation.stds == 0.05
-    assert parent_job.execution_time is not None
+    assert parent_job.execution_time == 0.7
     assert parent_job.job_info.message == "child-0-message"
 
 

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -17,6 +17,7 @@ from oqtopus_engine_core.framework import (
     Step,
 )
 from oqtopus_engine_core.framework.context import GlobalContext
+from oqtopus_engine_core.framework.model import TranspileResult
 from oqtopus_engine_core.framework.pipeline import StepPhase
 from oqtopus_engine_core.steps.estimator_step import (
     ESTIMATION_CHILD_INDEX_KEY,
@@ -96,8 +97,9 @@ async def test_pre_process_uses_transpile_mapping_in_sorted_order(
     jctx = JobContext(initial={})
     job = _make_estimation_job("job-2")
     job.job_info.program = ["unused"]
-    job.job_info.transpile_result = SimpleNamespace(
+    job.job_info.transpile_result = TranspileResult(
         transpiled_program="TRANSPILED",
+        stats={},
         virtual_physical_mapping={"qubit_mapping": {"1": 0, "0": 2}},
     )
 

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -7,6 +7,7 @@ import pytest
 
 from oqtopus_engine_core.buffers import QueueBuffer
 from oqtopus_engine_core.framework import (
+    HAS_ACTUAL_CHILDREN_KEY,
     Job,
     JobContext,
     JobInfo,
@@ -21,7 +22,6 @@ from oqtopus_engine_core.framework.pipeline import StepPhase
 from oqtopus_engine_core.steps.estimator_step import (
     ESTIMATION_CHILD_INDEX_KEY,
     ESTIMATION_JOIN_INFO_KEY,
-    INTERNAL_JOB_KEY,
     EstimationJoinInfo,
     EstimatorStep,
 )
@@ -82,7 +82,7 @@ async def test_pre_process_calls_grpc_and_creates_children(
     assert len(jctx.children) == 2
     assert join_info.child_order == [child.job_id for child in job.children]
     assert all(child.job_type == "sampling" for child in job.children)
-    assert jctx.children[0][INTERNAL_JOB_KEY] is True
+    assert jctx.children[0][HAS_ACTUAL_CHILDREN_KEY] is False
     assert jctx.children[0][ESTIMATION_CHILD_INDEX_KEY] == 0
     assert jctx.children[1][ESTIMATION_CHILD_INDEX_KEY] == 1
 
@@ -201,7 +201,10 @@ class FakeSamplingExecutionStep(Step):
         """Populate counts for internal sampling children."""
 
     async def post_process(self, gctx, jctx, job):
-        if jctx.get(INTERNAL_JOB_KEY):
+        if (
+            HAS_ACTUAL_CHILDREN_KEY in jctx
+            and not jctx.get(HAS_ACTUAL_CHILDREN_KEY, False)
+        ):
             index = jctx[ESTIMATION_CHILD_INDEX_KEY]
             job.job_info.result = JobResult(
                 sampling=SamplingResult(counts={f"{index}": index + 1})

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -1,11 +1,47 @@
 import json
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from oqtopus_engine_core.framework.model import OperatorItem
-from oqtopus_engine_core.steps.estimator_step import EstimationJobInfo, EstimatorStep
+from oqtopus_engine_core.buffers import QueueBuffer
+from oqtopus_engine_core.framework import (
+    Job,
+    JobContext,
+    JobInfo,
+    JobResult,
+    OperatorItem,
+    PipelineExecutor,
+    SamplingResult,
+    Step,
+)
+from oqtopus_engine_core.framework.context import GlobalContext
+from oqtopus_engine_core.framework.pipeline import StepPhase
+from oqtopus_engine_core.steps.estimator_step import (
+    ESTIMATION_CHILD_INDEX_KEY,
+    ESTIMATION_JOIN_INFO_KEY,
+    INTERNAL_JOB_KEY,
+    EstimationJoinInfo,
+    EstimatorStep,
+)
+
+
+def _make_estimation_job(job_id: str = "job-1") -> Job:
+    return Job(
+        job_id=job_id,
+        job_type="estimation",
+        device_id="device-1",
+        shots=100,
+        job_info=JobInfo(
+            program=["OPENQASM 3.0;\n"],
+            operator=[OperatorItem(pauli="X 0", coeff=1.0)],
+        ),
+        transpiler_info={},
+        simulator_info={},
+        mitigation_info={"ro_error_mitigation": "pseudo_inverse"},
+        status="submitted",
+    )
 
 
 @pytest.fixture
@@ -18,30 +54,19 @@ def estimator_step_instance() -> EstimatorStep:
 
 
 @pytest.mark.asyncio
-async def test_pre_process_calls_grpc_and_updates_jctx(
+async def test_pre_process_calls_grpc_and_creates_children(
     estimator_step_instance: EstimatorStep,
 ) -> None:
     gctx = MagicMock()
-    jctx: dict[str, object] = {}
-    job = MagicMock()
-    job.job_id = "job-1"
-    job.job_type = "estimation"
-    job.job_info.transpile_result = None
-    job.job_info.program = ["OPENQASM 3.0;\n"]
-    job.job_info.operator = [OperatorItem(pauli="X 0", coeff=1.0)]
+    jctx = JobContext(initial={})
+    job = _make_estimation_job()
 
     estimator_step_instance._stub.ReqEstimationPreProcess.return_value = SimpleNamespace(
-        qasm_codes=["preprocessed-qasm"],
-        grouped_operators=json.dumps([[ ["X"] ], [ [1.0] ]]),
+        qasm_codes=["preprocessed-qasm-0", "preprocessed-qasm-1"],
+        grouped_operators=json.dumps([[["X"]], [[1.0]]]),
     )
 
     await estimator_step_instance.pre_process(gctx, jctx, job)
-
-    assert "estimation_job_info" in jctx
-    info = jctx["estimation_job_info"]
-    assert isinstance(info, EstimationJobInfo)
-    assert info.preprocessed_qasms == ["preprocessed-qasm"]
-    assert info.grouped_operators == [[["X"]], [[1.0]]]
 
     estimator_step_instance._stub.ReqEstimationPreProcess.assert_awaited_once()
     request = estimator_step_instance._stub.ReqEstimationPreProcess.call_args.args[0]
@@ -50,18 +75,26 @@ async def test_pre_process_calls_grpc_and_updates_jctx(
     assert list(request.basis_gates) == ["cx", "rz", "sx", "measure"]
     assert list(request.mapping_list) == []
 
+    join_info = jctx[ESTIMATION_JOIN_INFO_KEY]
+    assert isinstance(join_info, EstimationJoinInfo)
+    assert join_info.grouped_operators == [[["X"]], [[1.0]]]
+    assert len(job.children) == 2
+    assert len(jctx.children) == 2
+    assert join_info.child_order == [child.job_id for child in job.children]
+    assert all(child.job_type == "sampling" for child in job.children)
+    assert jctx.children[0][INTERNAL_JOB_KEY] is True
+    assert jctx.children[0][ESTIMATION_CHILD_INDEX_KEY] == 0
+    assert jctx.children[1][ESTIMATION_CHILD_INDEX_KEY] == 1
+
 
 @pytest.mark.asyncio
 async def test_pre_process_uses_transpile_mapping_in_sorted_order(
     estimator_step_instance: EstimatorStep,
 ) -> None:
     gctx = MagicMock()
-    jctx: dict[str, object] = {}
-    job = MagicMock()
-    job.job_id = "job-2"
-    job.job_type = "estimation"
+    jctx = JobContext(initial={})
+    job = _make_estimation_job("job-2")
     job.job_info.program = ["unused"]
-    job.job_info.operator = [OperatorItem(pauli="Z 1", coeff=2.0)]
     job.job_info.transpile_result = SimpleNamespace(
         transpiled_program="TRANSPILED",
         virtual_physical_mapping={"qubit_mapping": {"1": 0, "0": 2}},
@@ -69,7 +102,7 @@ async def test_pre_process_uses_transpile_mapping_in_sorted_order(
 
     estimator_step_instance._stub.ReqEstimationPreProcess.return_value = SimpleNamespace(
         qasm_codes=["qasm"],
-        grouped_operators=json.dumps([[ ["Z"] ], [ [2.0] ]]),
+        grouped_operators=json.dumps([[["Z"]], [[2.0]]]),
     )
 
     await estimator_step_instance.pre_process(gctx, jctx, job)
@@ -84,12 +117,8 @@ async def test_pre_process_raises_when_operator_missing(
     estimator_step_instance: EstimatorStep,
 ) -> None:
     gctx = MagicMock()
-    jctx: dict[str, object] = {}
-    job = MagicMock()
-    job.job_id = "job-3"
-    job.job_type = "estimation"
-    job.job_info.transpile_result = None
-    job.job_info.program = ["OPENQASM 3.0;\n"]
+    jctx = JobContext(initial={})
+    job = _make_estimation_job("job-3")
     job.job_info.operator = None
 
     with pytest.raises(ValueError, match="operator is not specified"):
@@ -97,48 +126,147 @@ async def test_pre_process_raises_when_operator_missing(
 
 
 @pytest.mark.asyncio
-async def test_post_process_calls_grpc_and_updates_job_result(
+async def test_join_jobs_calls_grpc_and_updates_parent_result(
     estimator_step_instance: EstimatorStep,
 ) -> None:
     gctx = MagicMock()
-    job = MagicMock()
-    job.job_id = "job-4"
-    job.job_type = "estimation"
-    job.job_info.result = None
+    parent_job = _make_estimation_job("job-4")
+    parent_job.children = [
+        Job(
+            job_id="job-4-estimation-child-1",
+            job_type="sampling",
+            device_id="device-1",
+            shots=100,
+            job_info=JobInfo(
+                program=["qasm-1"],
+                result=JobResult(sampling=SamplingResult(counts={"11": 20, "00": 10})),
+                message="child-1-message",
+            ),
+            transpiler_info={},
+            simulator_info={},
+            mitigation_info={},
+            status="running",
+        ),
+        Job(
+            job_id="job-4-estimation-child-0",
+            job_type="sampling",
+            device_id="device-1",
+            shots=100,
+            job_info=JobInfo(
+                program=["qasm-0"],
+                result=JobResult(sampling=SamplingResult(counts={"01": 5, "10": 7})),
+                message="child-0-message",
+            ),
+            transpiler_info={},
+            simulator_info={},
+            mitigation_info={},
+            status="running",
+        ),
+    ]
 
-    jctx = {
-        "estimation_job_info": SimpleNamespace(
-            counts_list=[{"00": 10, "11": 20}],
-            grouped_operators=[[["ZZ"]], [[1.0]]],
-        )
-    }
+    join_info = EstimationJoinInfo()
+    join_info.grouped_operators = [[["ZZ"]], [[1.0]]]
+    join_info.child_order = [
+        "job-4-estimation-child-0",
+        "job-4-estimation-child-1",
+    ]
+    join_info.started_at = time.perf_counter() - 0.25
+    parent_jctx = JobContext(initial={ESTIMATION_JOIN_INFO_KEY: join_info})
 
     estimator_step_instance._stub.ReqEstimationPostProcess.return_value = SimpleNamespace(
         expval=0.25,
         stds=0.05,
     )
 
-    await estimator_step_instance.post_process(gctx, jctx, job)
+    await estimator_step_instance.join_jobs(
+        gctx=gctx,
+        parent_jctx=parent_jctx,
+        parent_job=parent_job,
+        last_child=parent_job.children[1],
+    )
 
-    estimator_step_instance._stub.ReqEstimationPostProcess.assert_awaited_once()
     request = estimator_step_instance._stub.ReqEstimationPostProcess.call_args.args[0]
-    assert len(request.counts) == 1
-    assert dict(request.counts[0].counts) == {"00": 10, "11": 20}
+    assert len(request.counts) == 2
+    assert dict(request.counts[0].counts) == {"01": 5, "10": 7}
+    assert dict(request.counts[1].counts) == {"11": 20, "00": 10}
     assert json.loads(request.grouped_operators) == [[["ZZ"]], [[1.0]]]
+    assert parent_job.job_info.result.estimation.exp_value == 0.25
+    assert parent_job.job_info.result.estimation.stds == 0.05
+    assert parent_job.execution_time is not None
+    assert parent_job.job_info.message == "child-0-message"
 
-    assert job.job_info.result is not None
-    assert job.job_info.result.estimation is not None
-    assert job.job_info.result.estimation.exp_value == 0.25
-    assert job.job_info.result.estimation.stds == 0.05
+
+class FakeSamplingExecutionStep(Step):
+    async def pre_process(self, gctx, jctx, job):
+        """Populate counts for internal sampling children."""
+
+    async def post_process(self, gctx, jctx, job):
+        if jctx.get(INTERNAL_JOB_KEY):
+            index = jctx[ESTIMATION_CHILD_INDEX_KEY]
+            job.job_info.result = JobResult(
+                sampling=SamplingResult(counts={f"{index}": index + 1})
+            )
+            job.job_info.message = f"child-{index}"
 
 
 @pytest.mark.asyncio
-async def test_non_estimation_jobs_are_skipped(estimator_step_instance: EstimatorStep) -> None:
+async def test_same_step_split_and_join_flow() -> None:
+    estimator_step = EstimatorStep()
+    estimator_step._stub = MagicMock()
+    estimator_step._stub.ReqEstimationPreProcess = AsyncMock(
+        return_value=SimpleNamespace(
+            qasm_codes=["qasm-0", "qasm-1"],
+            grouped_operators=json.dumps([[["X"]], [[1.0]]]),
+        )
+    )
+    estimator_step._stub.ReqEstimationPostProcess = AsyncMock(
+        return_value=SimpleNamespace(expval=0.75, stds=0.125)
+    )
+
+    pipeline = [estimator_step, FakeSamplingExecutionStep()]
+    executor = PipelineExecutor(pipeline, QueueBuffer())
+    parent_job = _make_estimation_job("root")
+    parent_jctx = JobContext(initial={})
+
+    await executor._run_from(
+        StepPhase.PRE_PROCESS,
+        0,
+        GlobalContext(config={}),
+        parent_jctx,
+        parent_job,
+    )
+
+    assert parent_job.job_info.result.estimation.exp_value == 0.75
+    assert parent_job.job_info.result.estimation.stds == 0.125
+    assert parent_job.job_info.message == "child-1"
+    assert parent_jctx.step_history == [
+        ("pre_process", 0),
+    ]
+    for child_jctx in parent_jctx.children:
+        assert child_jctx.step_history == [
+            ("pre_process", 1),
+            ("post_process", 1),
+            ("post_process", 0),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_non_estimation_jobs_are_skipped(
+    estimator_step_instance: EstimatorStep,
+) -> None:
     gctx = MagicMock()
-    jctx: dict[str, object] = {}
-    job = MagicMock()
-    job.job_id = "job-5"
-    job.job_type = "sampling"
+    jctx = JobContext(initial={})
+    job = Job(
+        job_id="job-5",
+        job_type="sampling",
+        device_id="device-1",
+        shots=100,
+        job_info=JobInfo(program=["OPENQASM 3.0;\n"]),
+        transpiler_info={},
+        simulator_info={},
+        mitigation_info={},
+        status="submitted",
+    )
 
     await estimator_step_instance.pre_process(gctx, jctx, job)
     await estimator_step_instance.post_process(gctx, jctx, job)

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -21,6 +21,7 @@ from oqtopus_engine_core.framework.pipeline import StepPhase
 from oqtopus_engine_core.steps.estimator_step import (
     ESTIMATION_CHILD_INDEX_KEY,
     ESTIMATION_JOIN_INFO_KEY,
+    ESTIMATOR_STEP_NAME,
     EstimationJoinInfo,
     EstimatorStep,
 )
@@ -277,3 +278,18 @@ async def test_non_estimation_jobs_are_skipped(
 
     estimator_step_instance._stub.ReqEstimationPreProcess.assert_not_awaited()
     estimator_step_instance._stub.ReqEstimationPostProcess.assert_not_awaited()
+    assert ESTIMATOR_STEP_NAME in jctx["split_skip_steps"]
+    assert ESTIMATOR_STEP_NAME in jctx["join_skip_steps"]
+
+
+@pytest.mark.asyncio
+async def test_estimation_parent_skips_join_gate(
+    estimator_step_instance: EstimatorStep,
+) -> None:
+    gctx = MagicMock()
+    jctx = JobContext(initial={})
+    job = _make_estimation_job("job-6")
+
+    await estimator_step_instance.post_process(gctx, jctx, job)
+
+    assert ESTIMATOR_STEP_NAME in jctx["join_skip_steps"]

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -7,7 +7,6 @@ import pytest
 
 from oqtopus_engine_core.buffers import QueueBuffer
 from oqtopus_engine_core.framework import (
-    HAS_ACTUAL_CHILDREN_KEY,
     Job,
     JobContext,
     JobInfo,
@@ -82,7 +81,8 @@ async def test_pre_process_calls_grpc_and_creates_children(
     assert len(jctx.children) == 2
     assert join_info.child_order == [child.job_id for child in job.children]
     assert all(child.job_type == "sampling" for child in job.children)
-    assert jctx.children[0][HAS_ACTUAL_CHILDREN_KEY] is False
+    assert "has_actual_children" not in jctx.children[0]
+    assert jctx.children[0]["has_actual_parent"] is True
     assert jctx.children[0][ESTIMATION_CHILD_INDEX_KEY] == 0
     assert jctx.children[1][ESTIMATION_CHILD_INDEX_KEY] == 1
 
@@ -204,8 +204,7 @@ class FakeSamplingExecutionStep(Step):
 
     async def post_process(self, gctx, jctx, job):
         if (
-            HAS_ACTUAL_CHILDREN_KEY in jctx
-            and not jctx.get(HAS_ACTUAL_CHILDREN_KEY, False)
+            jctx.get("has_actual_parent", False)
         ):
             index = jctx[ESTIMATION_CHILD_INDEX_KEY]
             job.job_info.result = JobResult(

--- a/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_estimator_step.py
@@ -133,7 +133,7 @@ async def test_join_jobs_calls_grpc_and_updates_parent_result(
     parent_job = _make_estimation_job("job-4")
     parent_job.children = [
         Job(
-            job_id="job-4-estimation-child-1",
+            job_id="job-4-1",
             job_type="sampling",
             device_id="device-1",
             shots=100,
@@ -149,7 +149,7 @@ async def test_join_jobs_calls_grpc_and_updates_parent_result(
             execution_time=0.4,
         ),
         Job(
-            job_id="job-4-estimation-child-0",
+            job_id="job-4-0",
             job_type="sampling",
             device_id="device-1",
             shots=100,
@@ -169,8 +169,8 @@ async def test_join_jobs_calls_grpc_and_updates_parent_result(
     join_info = EstimationJoinInfo()
     join_info.grouped_operators = [[["ZZ"]], [[1.0]]]
     join_info.child_order = [
-        "job-4-estimation-child-0",
-        "job-4-estimation-child-1",
+        "job-4-0",
+        "job-4-1",
     ]
     join_info.started_at = time.perf_counter() - 0.25
     parent_jctx = JobContext(initial={ESTIMATION_JOIN_INFO_KEY: join_info})

--- a/core/tests/oqtopus_engine_core/steps/test_ro_error_mitigation_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_ro_error_mitigation_step.py
@@ -89,60 +89,18 @@ async def test_post_process_skips_when_mitigation_is_unset(
 
 
 @pytest.mark.asyncio
-async def test_post_process_estimation_uses_preprocessed_qasm_and_fallback(
-    mitigation_step: ReadoutErrorMitigationStep,
-) -> None:
-    gctx = MagicMock()
-    gctx.device.device_info = json.dumps(
-        {
-            "qubits": [
-                {"meas_error": {"prob_meas1_prep0": 0.01, "prob_meas0_prep1": 0.02}},
-            ]
-        }
-    )
-
-    job = MagicMock()
-    job.job_id = "job-2"
-    job.job_type = "estimation"
-    job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
-    job.job_info.program = ["fallback-program"]
-
-    estimation_job_info = SimpleNamespace(
-        counts_list=[{"0": 10}, {"1": 20}],
-        preprocessed_qasms=["qasm-0"],
-    )
-    jctx = {"estimation_job_info": estimation_job_info}
-
-    mitigation_step._stub.ReqMitigation.side_effect = [
-        SimpleNamespace(counts={"0": 9}),
-        SimpleNamespace(counts={"1": 19}),
-    ]
-
-    await mitigation_step.post_process(gctx, jctx, job)
-
-    assert mitigation_step._stub.ReqMitigation.await_count == 2
-    first_request = mitigation_step._stub.ReqMitigation.await_args_list[0].args[0]
-    second_request = mitigation_step._stub.ReqMitigation.await_args_list[1].args[0]
-
-    assert first_request.program == "qasm-0"
-    assert second_request.program == "fallback-program"
-    assert estimation_job_info.counts_list == [{"0": 9}, {"1": 19}]
-
-
-@pytest.mark.asyncio
-async def test_post_process_estimation_without_counts_list_returns_early(
+async def test_post_process_non_sampling_job_is_skipped(
     mitigation_step: ReadoutErrorMitigationStep,
 ) -> None:
     gctx = MagicMock()
     gctx.device.device_info = json.dumps({"qubits": []})
 
     job = MagicMock()
-    job.job_id = "job-3"
+    job.job_id = "job-2"
     job.job_type = "estimation"
     job.mitigation_info = {"ro_error_mitigation": "pseudo_inverse"}
+    job.job_info.program = ["ignored-program"]
 
-    jctx = {"estimation_job_info": SimpleNamespace(counts_list=None)}
-
-    await mitigation_step.post_process(gctx, jctx, job)
+    await mitigation_step.post_process(gctx, {}, job)
 
     mitigation_step._stub.ReqMitigation.assert_not_awaited()

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:06:12.201295161Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"

--- a/docs/developer_guidelines/implementing_pipeline.md
+++ b/docs/developer_guidelines/implementing_pipeline.md
@@ -74,6 +74,7 @@ Once **all** child jobs have passed through the join step, the `join_jobs()` met
 
 ```python
 from oqtopus_engine_core.framework import Step, SplitOnPreprocess
+from oqtopus_engine_core.framework.context import link_parent_and_children
 
 class MySplitStep(Step, SplitOnPreprocess):
     async def pre_process(
@@ -91,10 +92,9 @@ class MySplitStep(Step, SplitOnPreprocess):
             child_jobs.append(c_job)
             child_ctxs.append(c_jctx)
 
-        # When implementing a split step manually, you must explicitly assign
-        # the children to both job.children and jctx.children.
-        job.children = child_jobs
-        jctx.children = child_ctxs
+        # Use the utility to establish bidirectional links between parent and children.
+        # This replaces manual assignments to job.children and jctx.children.
+        link_parent_and_children(jctx, job, child_ctxs, child_jobs)
 
     async def post_process(
         self,
@@ -109,8 +109,6 @@ class MySplitStep(Step, SplitOnPreprocess):
 
 The executor automatically:
 
-- sets the parent attribute on both the child job and child JobContext
-  (establishing a bidirectional link between the parent job and each child),
 - pauses parent execution at the split point,
 - schedules child pipelines independently,
 - resumes the parent only after join.

--- a/estimator/uv.lock
+++ b/estimator/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:06:56.732846572Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "antlr4-python3-runtime"
 version = "4.13.2"

--- a/mitigator/uv.lock
+++ b/mitigator/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:06:37.419353239Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"

--- a/sse_runtime/uv.lock
+++ b/sse_runtime/uv.lock
@@ -7,10 +7,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "2026-03-27T06:07:34.6775405Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "appdirs"
 version = "1.4.4"


### PR DESCRIPTION
# 📃 Ticket
#32 

## Summary
- add split/join-based estimation execution in `EstimatorStep`
- use explicit jctx markers for parent/child split contexts
- prevent internal estimation child jobs from sending Cloud status updates
- aggregate child execution time into the parent estimation job
- generate child job IDs from the parent job ID and child index

## Validation
- `cd core && uv run ruff check`
- `cd core && uv run pytest tests/oqtopus_engine_core/framework/test_pipeline.py tests/oqtopus_engine_core/steps/test_estimator_step.py tests/oqtopus_engine_core/steps/test_device_gateway_step.py`
- verified locally with an estimation job on the local cloud + engine stack