### PR TITLE
Enhance multi-programming auto features and update documentation (#51)

### DIFF
--- a/combiner/uv.lock
+++ b/combiner/uv.lock
@@ -12,15 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "absl-py"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/2a/c93173ffa1b39c1d0395b7e842bbdc62e556ca9d8d3b5572926f3e4ca752/absl_py-2.3.1.tar.gz", hash = "sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9", size = 116588, upload-time = "2025-07-03T09:31:44.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl", hash = "sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d", size = 135811, upload-time = "2025-07-03T09:31:42.253Z" },
-]
-
-[[package]]
 name = "antlr4-python3-runtime"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
* chore: update version to v2.0.2 (#29)

* Add dynamic split/join control via JobContext in PipelineExecutor (#31)

* Initial plan

* Add dynamic split/join control via JobContext in PipelineExecutor



---------




* Add split_skip_steps and join_skip_steps to PipelineExecutor (#33)

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/622c80c9-1cc9-48d5-89fe-31208ccabdb4




* feat: [multi-programming auto] combiner for mp-auto (#35)

* feat: Update combiner docker for multi-programming auto

* feat: update Makefile and compose file of combiner

* feat: update the interface of combiner

* refactor: update combiner interface

* fix:revert unintended push

* chore: remove unused import

* feat:update unit testing

* refactor: Change the timing to reverse the order of qubits list for multi-programming

* refactor: refactor codes and comments of combiner

* feat: [multi-programming auto] add new gRPC interface (#34)

* feat: Update spec for multi-programming auto

* chore: update example doc in combiner spec

* chore: Add descriptions of example in combiner proto

* feat: [multi-programming auto] add buffer and step for mp-auto into core pipeline (#36)

* feat: Add multi-programming auto combining

* feat: update the interface of combiner

* feat: update default config value of multi-programming auto

* refactor: update class/function comments

* feat:Update to support a framework change regarding splitting job and some refactoring

* feat: Use split_skip_steps instead of split_enabled_steps to cancel splitting in MpAutoCombining

* refactor: Change the timing to reverse the order of qubits list for multi-programming

* refactor: refactor codes and comments in mp auto combining

* refactor: Change job_id of mock jobs to dynamic (#37)

* feat: Add environment variables for mp auto to the config (#38)

* feat: Add environment variables for mp auto to the config

* fix: Fixed an oversight in unit testing when the divider for multi-programming was updated

* Add combiner_address to MpAutoCombiningBuffer config (#39)

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/ba4b8a7a-44a1-420e-abb9-6c71ed4427ae




* Remove redundant di_container config log line (#40)

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/9e0faf90-6b89-4b9a-9448-cc6de599b5bf




* docs: simplify config.yaml and sse_engine_config.yaml descriptions (#41)

* Add config sample docs and link from index

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/c2380065-3b6a-4797-b117-3cdac7a52482



* Add section descriptions to config.md

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/a3eb6d2b-11ef-4e6b-86d4-c8abffe13cc7



* Update section descriptions in config.md to specified text

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/3cd97b98-7b11-4286-8c6a-32a0cda60d17



---------




* update version to v2.0.3 (#43)

* Feat/estimator same step split join (#42)

* Refactor estimator split/join flow

* feat: implement async execution lock for device gateway jobs

* refactor: remove unused post-return index handling in PipelineExecutor

* feat: Introduce HAS_ACTUAL_CHILDREN_KEY for better child context management in pipeline and estimator steps

* fix: Update parent job execution time calculation to sum child execution times

* refactor: Simplify child job ID format in EstimatorStep and related tests

* refactor: Replace HAS_ACTUAL_CHILDREN_KEY with string literal and update related logic

* refactor: Enhance docstrings for clarity and add return descriptions in estimator and readout error mitigation steps

* feat: Implement skip step logic for split/join gating in EstimatorStep

* Update pipeline to not set has_actual_parent (should be set in steps)

* Update lock scope and status update conditions in DeviceGatewayStep

* Update child_job_id naming rule

* Update test case

* set transpile_result to children in EstimatorStep

* feat: enable integration of MP auto-combining and EstimatorStep

* docs: update docs

* update code

* update uv.lock

---------



* Add comment explaining why only children are linked before combining (#45)

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/20c7e928-45f5-44a1-9683-d79eda928429




* fix: reset pipeline_directive to NONE per step via try/finally inside while loop (#46)

* feat: introduce PipelineDirective to fix remaining_children leak in MpAutoCombiningStep

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/7cc35337-7825-4420-8c17-e51c2bafcd04



* fix: remove unused variables in test_ignore_split_tracking_directive_is_consumed_once

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/7cc35337-7825-4420-8c17-e51c2bafcd04



* docs: document PipelineDirective in implementing_pipeline.md

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/002d262b-af82-4473-a948-0faecf947d32



* docs: move JobContext Usage before PipelineDirective in implementing_pipeline.md

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/1d92351d-2f15-4ee8-b709-bc19ce4e440a



* fix: reset pipeline_directive to NONE per step via try/finally inside while loop

Agent-Logs-Url: https://github.com/oqtopus-team/oqtopus-engine/sessions/0cb4b896-8dc9-4b2a-b4ec-05dec88c7f96



* fix logic and docs

---------





* chore: Remove duplicate packages (#49)

---------

# 📃 Ticket
<!--- Paste related ticket -->

## ✍ Description
<!--- Describe your changes in detail -->

## 📸 Test Result
<!--- Paste `make test result` -->

## 🔗 Related PRs
<!--- Paste related PRs -->
