### PR TITLE
version 2.0.4

### DIFF
--- a/combiner/pyproject.toml
+++ b/combiner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oqtopus-engine-combiner"
-version = "2.0.3"
+version = "2.0.4"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "oqtopus-team", email = "oqtopus-team@googlegroups.com" }]

--- a/combiner/uv.lock
+++ b/combiner/uv.lock
@@ -527,7 +527,7 @@ parser = [
 
 [[package]]
 name = "oqtopus-engine-combiner"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oqtopus-engine-core"
-version = "2.0.3"
+version = "2.0.4"
 description = "OQTOPUS Engine in the backend layer retrieves jobs managed in OQTOPUS Cloud and executes quantum programs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:06:12.201295161Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -367,7 +363,7 @@ parser = [
 
 [[package]]
 name = "oqtopus-engine-core"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },

--- a/estimator/pyproject.toml
+++ b/estimator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oqtopus-engine-estimator"
-version = "2.0.3"
+version = "2.0.4"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "oqtopus-team", email = "oqtopus-team@googlegroups.com" }]

--- a/estimator/uv.lock
+++ b/estimator/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:06:56.732846572Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "antlr4-python3-runtime"
 version = "4.13.2"
@@ -301,7 +297,7 @@ parser = [
 
 [[package]]
 name = "oqtopus-engine-estimator"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/mitigator/pyproject.toml
+++ b/mitigator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oqtopus-engine-mitigator"
-version = "2.0.3"
+version = "2.0.4"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "oqtopus-team", email = "oqtopus-team@googlegroups.com" }]

--- a/mitigator/uv.lock
+++ b/mitigator/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <4.0"
 
-[options]
-exclude-newer = "2026-03-27T06:06:37.419353239Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -310,7 +306,7 @@ parser = [
 
 [[package]]
 name = "oqtopus-engine-mitigator"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/sse_runtime/pyproject.toml
+++ b/sse_runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sse-runtime"
-version = "2.0.3"
+version = "2.0.4"
 description = "SSE Runtime: A runtime container for SSE"
 license = "Apache-2.0"
 authors = [{ name = "oqtopus-team", email = "oqtopus-team@googlegroups.com" }]

--- a/sse_runtime/uv.lock
+++ b/sse_runtime/uv.lock
@@ -7,10 +7,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "2026-03-27T06:07:34.6775405Z"
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "appdirs"
 version = "1.4.4"
@@ -1742,7 +1738,7 @@ wheels = [
 
 [[package]]
 name = "sse-runtime"
-version = "2.0.3"
+version = "2.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "cirq" },


### PR DESCRIPTION
This pull request updates the version number from `2.0.3` to `2.0.4` across all engine and runtime components. No other changes are included. This ensures consistency in versioning for the `combiner`, `core`, `estimator`, `mitigator`, and `sse_runtime` packages.

Version bump for release:

* Updated the `version` field to `2.0.4` in `combiner/pyproject.toml`
* Updated the `version` field to `2.0.4` in `core/pyproject.toml`
* Updated the `version` field to `2.0.4` in `estimator/pyproject.toml`
* Updated the `version` field to `2.0.4` in `mitigator/pyproject.toml`
* Updated the `version` field to `2.0.4` in `sse_runtime/pyproject.toml`