### PR TITLE
Feat/mp auto buffer qubits

### DIFF
--- a/combiner/Makefile
+++ b/combiner/Makefile
@@ -6,7 +6,7 @@ LOG_DIR ?= logs
 
 .PHONY: run, test
 run:
-	@WORKERS=10 ADDRESS="localhost:52013" uv run python src/oqtopus_engine_combiner/app.py -c config/config.yaml -l config/logging.yaml
+	@WORKERS=10 ADDRESS="localhost:52013" IDLE_QUBITS_INSERTION_ENABLED="false" uv run python src/oqtopus_engine_combiner/app.py -c config/config.yaml -l config/logging.yaml
 
 build:
 	@docker compose build

--- a/combiner/config/config.yaml
+++ b/combiner/config/config.yaml
@@ -1,3 +1,5 @@
 proto: # Settings for gRPC server
   max_workers: ${WORKERS} # Maximum number of workers
   address: "${ADDRESS}" # Address and port for RPCs
+combiner:
+  idle_qubits_insertion_enabled: "${IDLE_QUBITS_INSERTION_ENABLED}" # Enable or disable insertion of idle qubits (true/false)

--- a/combiner/src/oqtopus_engine_combiner/app.py
+++ b/combiner/src/oqtopus_engine_combiner/app.py
@@ -102,6 +102,9 @@ class CircuitCombiner(CombinerService):
 
     """
 
+    def __init__(self, *, idle_qubits_insertion_enabled: bool = False) -> None:
+        self._idle_qubits_insertion_enabled = idle_qubits_insertion_enabled
+
     def Combine(  # noqa: N802
         self,
         request: CombineRequest,
@@ -300,7 +303,9 @@ class CircuitCombiner(CombinerService):
             device_info = json.loads(request.device_info)
 
             combined_groups = []
-            combiner = OptimalCircuitCombiner()
+            combiner = OptimalCircuitCombiner(
+                idle_qubits_insertion_enabled=self._idle_qubits_insertion_enabled
+            )
             # assign qubits to each circuit and create groups to be combined
             assigned_ids, assigned_groups = combiner.assign_circuits(jobs=jobs,
                                                                      device_info=device_info
@@ -448,11 +453,16 @@ def serve(config_yaml_path: str, logging_yaml_path: str) -> None:
         logging.config.dictConfig(logging_yaml)
 
     max_workers = int(config_yaml["proto"].get("max_workers") or 10)
-    # create a gRPC server
     address = str(config_yaml["proto"].get("address") or "[::]:52013")
+    str_idle_qubits_insertion_enabled = str(config_yaml["combiner"].get("idle_qubits_insertion_enabled") or "false")
+    idle_qubits_insertion_enabled = str_idle_qubits_insertion_enabled.lower() == "true"
+
     # create the gRPC server
     server = grpc.server(futures.ThreadPoolExecutor(max_workers))
-    add_CombinerServiceServicer_to_server(CircuitCombiner(), server)
+    add_CombinerServiceServicer_to_server(
+        CircuitCombiner(idle_qubits_insertion_enabled=idle_qubits_insertion_enabled),
+        server,
+    )
 
     service_names = (
         DESCRIPTOR.services_by_name["CombinerService"].full_name,
@@ -465,6 +475,7 @@ def serve(config_yaml_path: str, logging_yaml_path: str) -> None:
         extra={
             "address": address,
             "max_workers": max_workers,
+            "idle_qubits_insertion_enabled": idle_qubits_insertion_enabled,
         },
     )
 

--- a/combiner/src/oqtopus_engine_combiner/app.py
+++ b/combiner/src/oqtopus_engine_combiner/app.py
@@ -454,7 +454,8 @@ def serve(config_yaml_path: str, logging_yaml_path: str) -> None:
 
     max_workers = int(config_yaml["proto"].get("max_workers") or 10)
     address = str(config_yaml["proto"].get("address") or "[::]:52013")
-    str_idle_qubits_insertion_enabled = str(config_yaml["combiner"].get("idle_qubits_insertion_enabled") or "false")
+    str_idle_qubits_insertion_enabled = \
+        str(config_yaml["combiner"].get("idle_qubits_insertion_enabled") or "false")
     idle_qubits_insertion_enabled = str_idle_qubits_insertion_enabled.lower() == "true"
 
     # create the gRPC server

--- a/combiner/src/oqtopus_engine_combiner/mp_auto.py
+++ b/combiner/src/oqtopus_engine_combiner/mp_auto.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 TARGET_SIZE = 30
 DEBUG_DRAW_GRAPH = False
+POSITION_EPSILON = 1e-9
 
 
 class JobWithCircuitGraph:
@@ -130,6 +131,10 @@ class OptimalCircuitCombiner:
 
     """
 
+    def __init__(self, *, idle_qubits_insertion_enabled: bool = False) -> None:
+        # This variable determines whether idle qubits are considered for assignment.
+        self._idle_qubits_insertion_enabled = idle_qubits_insertion_enabled
+
     @staticmethod
     def create_topology_graph(topology_json: dict[str, Any]) -> nx.Graph:
         """Create a networkx graph from the device topology JSON.
@@ -151,6 +156,134 @@ class OptimalCircuitCombiner:
             g.add_edge(coupling["control"], coupling["target"])
 
         return g
+
+    @staticmethod
+    def create_device_grid_graph(topology_json: dict[str, Any]) -> nx.Graph:
+        """Create a position-completed grid graph from device topology.
+
+        This function keeps existing couplings and fills in missing edges between
+        orthogonally adjacent qubits based on their position. The x/y thresholds
+        for adjacency are inferred from the maximum |dx| and |dy| among qubit pairs
+        that are already connected in the topology.
+
+        Args:
+            topology_json: Device topology in JSON format.
+
+        Returns:
+            A networkx undirected graph representing the completed device grid.
+
+        """
+        qubits = topology_json["qubits"]
+        couplings = topology_json["couplings"]
+        positions = {
+            qubit["id"]: (
+                float(qubit["position"]["x"]),
+                float(qubit["position"]["y"]),
+            )
+            for qubit in qubits
+        }
+
+        grid = nx.Graph()
+        grid.add_nodes_from(positions)
+        for coupling in couplings:
+            grid.add_edge(coupling["control"], coupling["target"])
+
+        x_threshold, y_threshold = OptimalCircuitCombiner._infer_grid_thresholds(
+            positions,
+            couplings,
+        )
+
+        qubit_ids = list(positions)
+        for index, source in enumerate(qubit_ids):
+            for target in qubit_ids[index + 1:]:
+                if not OptimalCircuitCombiner._is_orthogonal_neighbor(
+                    positions[source],
+                    positions[target],
+                    x_threshold,
+                    y_threshold,
+                ):
+                    continue
+                grid.add_edge(source, target)
+
+        return grid
+
+    @staticmethod
+    def _infer_grid_thresholds(
+        positions: dict[int, tuple[float, float]],
+        couplings: list[dict[str, Any]],
+    ) -> tuple[float, float]:
+        """Infer adjacency thresholds from existing coupled qubit pairs.
+
+        Arguments:
+            positions: A mapping of qubit IDs to their (x, y) positions.
+            couplings: A list of existing couplings between qubits.
+
+        Returns:
+            A tuple containing the inferred x and y thresholds for adjacency.
+
+        """
+        x_threshold = 0.0
+        y_threshold = 0.0
+
+        for coupling in couplings:
+            control_position = positions.get(coupling["control"])
+            target_position = positions.get(coupling["target"])
+            if control_position is None or target_position is None:
+                continue
+
+            x_threshold = max(
+                x_threshold,
+                abs(control_position[0] - target_position[0]),
+            )
+            y_threshold = max(
+                y_threshold,
+                abs(control_position[1] - target_position[1]),
+            )
+
+        return x_threshold, y_threshold
+
+    @staticmethod
+    def _is_orthogonal_neighbor(
+        source_position: tuple[float, float],
+        target_position: tuple[float, float],
+        x_threshold: float,
+        y_threshold: float,
+    ) -> bool:
+        """Return True when two positions are adjacent on the inferred grid.
+
+        Arguments:
+            source_position: (x, y) position of the source qubit.
+            target_position: (x, y) position of the target qubit.
+            x_threshold: Inferred threshold for x-axis adjacency.
+            y_threshold: Inferred threshold for y-axis adjacency.
+
+        Returns:
+            True if the two positions are orthogonally adjacent
+            based on the thresholds, False otherwise.
+
+        """
+        dx = abs(source_position[0] - target_position[0])
+        dy = abs(source_position[1] - target_position[1])
+
+        is_horizontal_neighbor = (
+            dy <= POSITION_EPSILON < dx <= x_threshold + POSITION_EPSILON
+        )
+        is_vertical_neighbor = (
+            dx <= POSITION_EPSILON < dy <= y_threshold + POSITION_EPSILON
+        )
+
+        if is_horizontal_neighbor and is_vertical_neighbor:
+            logger.warning(
+                "two qubits are in the same position or very close.",
+                extra={
+                    "source_position": source_position,
+                    "target_position": target_position,
+                    "x_threshold": x_threshold,
+                    "y_threshold": y_threshold,
+                }
+            )
+
+        return is_horizontal_neighbor or is_vertical_neighbor
 
     def combine_circuits_for_groups(
         self,
@@ -324,6 +457,10 @@ class OptimalCircuitCombiner:
         """
         # convert QPU topology to networkx graph
         topology = self.create_topology_graph(topology_json=device_info)
+        if self._idle_qubits_insertion_enabled:
+            inferred_topology = self.create_device_grid_graph(topology_json=device_info)
+        else:
+            inferred_topology = None
 
         # assigned job_id list
         assigned_ids = set()
@@ -351,7 +488,8 @@ class OptimalCircuitCombiner:
             )
 
             matches = self._find_nonoverlapping_subgraphs_with_t_nodes(topology,
-                                                                 current_batch
+                                                                 current_batch,
+                                                                 inferred_topology
                                                                  )
             assigned_group = []
             for match in matches:
@@ -414,14 +552,133 @@ class OptimalCircuitCombiner:
             logger.exception("failed to draw graph for debugging")
 
     @staticmethod
+    def _calculate_idle_nodes_before_mapping(
+        used_nodes: set[int],
+        exist_idle_nodes: set[int],
+        inferred_topology: nx.Graph | None,
+        g: nx.Graph
+    ) -> set[int]:
+        """Calculate idle nodes before mapping.
+
+        Arguments:
+            exist_idle_nodes: Set of idle nodes that already exist before mapping.
+            used_nodes: Set of nodes that have been used by assigned circuits.
+            inferred_topology: This graph representing the device connectivity.
+            g: Graph G representing the circuit to be mapped.
+
+        Returns:
+            A set of idle nodes that should be avoided for mapping the current circuit.
+
+        """
+        # If there is no edge in G (user circuit), this circuit does not have cnot gate.
+        # In this case, we do not consider idle nodes.
+        g_undirected = g.to_undirected()
+        if not g_undirected.number_of_edges() > 0:
+            return set()
+
+        # If there is no used node, return empty set.
+        if len(used_nodes) == 0:
+            if len(exist_idle_nodes) > 0:
+                logger.warning(
+                    "exist idle nodes but no used nodes, this should not happen",
+                    extra={
+                        "exist_idle_nodes": exist_idle_nodes,
+                        "used_nodes": used_nodes,
+                    }
+                )
+            return set()
+
+        # Calculate idle nodes that should be avoided for mapping.
+        idle_nodes = set()
+        if inferred_topology is not None:
+            undirected_inferred_t = inferred_topology.to_undirected()
+            for node in used_nodes:
+                idle_nodes.update(undirected_inferred_t.neighbors(node))
+        else:
+            logger.warning(
+                "inferred topology is None, cannot calculate idle nodes before mapping"
+            )
+
+        # remove used nodes and existing idle nodes from idle nodes
+        excluded_idle_nodes = used_nodes | exist_idle_nodes
+        idle_nodes.difference_update(excluded_idle_nodes)
+
+        return idle_nodes
+
+    @staticmethod
+    def _calculate_idle_nodes_after_mapping(
+        used_nodes: set[int],
+        exist_idle_nodes: set[int],
+        inferred_topology: nx.Graph | None,
+        g: nx.Graph,
+        result_mapping: dict[int, int],
+    ) -> set[int]:
+        """Calculate idle nodes after mapping.
+
+        Arguments:
+            used_nodes: Set of nodes that have been used by assigned circuits.
+            exist_idle_nodes: Set of idle nodes that already exist before mapping.
+            inferred_topology: This graph representing the device connectivity.
+            g: Graph G representing the circuit that has been mapped.
+            result_mapping: Mapping of nodes in G to nodes in T for the current circuit.
+
+        Returns:
+            A set of idle nodes that should be avoided for mapping.
+
+        """
+        # If there is no edge in G (user circuit), this circuit does not have cnot gate.
+        # In this case, we do not consider idle nodes.
+        g_undirected = g.to_undirected()
+        if not g_undirected.number_of_edges() > 0:
+            return set()
+
+        # Calculate idle nodes that should be avoided for mapping.
+        edge_endpoints = set()
+        for u, v in g_undirected.edges():
+            edge_endpoints.add(u)
+            edge_endpoints.add(v)
+
+        assigned_endpoint_nodes = set()
+        for edge_node in edge_endpoints:
+            value = result_mapping.get(edge_node)
+            if value is not None:
+                assigned_endpoint_nodes.add(value)
+            else:
+                logger.warning(
+                    "Edge endpoint not in result mapping, this should not happen",
+                    extra={
+                        "edge_node": edge_node,
+                        "result_mapping": result_mapping,
+                    }
+                )
+
+        idle_nodes = set()
+        if inferred_topology is not None:
+            undirected_inferred_t = inferred_topology.to_undirected()
+            for node in assigned_endpoint_nodes:
+                idle_nodes.update(undirected_inferred_t.neighbors(node))
+        else:
+            logger.warning(
+                "Inferred topology is None, cannot calculate idle nodes after mapping"
+            )
+
+        excluded_idle_nodes =\
+         used_nodes | exist_idle_nodes | set(result_mapping.values())
+        idle_nodes.difference_update(excluded_idle_nodes)
+
+        return idle_nodes
+
     def _find_nonoverlapping_subgraphs_with_t_nodes(
+        self,
         t: nx.Graph,
-        jobs: list[JobWithCircuitGraph]
+        jobs: list[JobWithCircuitGraph],
+        inferred_topology: nx.Graph | None = None
     ) -> list[dict[str, Any]]:
         """Find subgraphs in jobs' circuit graphs that can be mapped to T.
 
         Args:
             t: Target graph T representing the device connectivity.
+            inferred_topology: This graph representing the device connectivity.
             jobs: List of job dictionaries, each containing a 'circuit_graph' key
                 with the circuit's graph.
 
@@ -434,6 +691,7 @@ class OptimalCircuitCombiner:
 
         """
         used_nodes: set[int] = set()
+        idle_nodes: set[int] = set()
         results = []
 
         for idx, job in enumerate(jobs):
@@ -451,6 +709,18 @@ class OptimalCircuitCombiner:
             for m in mapping:
                 for used in used_nodes:
                     model.Add(m != used)
+
+            if self._idle_qubits_insertion_enabled:
+                # Calculate idle nodes that should be avoided for mapping.
+                current_idle_nodes = (
+                    idle_nodes
+                    | self._calculate_idle_nodes_before_mapping(
+                        used_nodes, idle_nodes, inferred_topology, g
+                    )
+                )
+                for m in mapping:
+                    for node in current_idle_nodes:
+                        model.Add(m != node)
 
             # Get the set of edges in T and create allowed pairs for mapping
             t_edges_set = set(t.edges())
@@ -487,6 +757,13 @@ class OptimalCircuitCombiner:
                     "T_nodes": mapped_t_nodes
                 })
 
+                if self._idle_qubits_insertion_enabled:
+                    # Calculate idle nodes that should be avoided for mapping.
+                    idle_nodes.update(
+                        self._calculate_idle_nodes_after_mapping(
+                            used_nodes, idle_nodes, inferred_topology, g, result_mapping
+                        )
+                    )
                 used_nodes.update(mapped_t_nodes)
             else:
                 logger.debug(

--- a/combiner/src/oqtopus_engine_combiner/mp_auto.py
+++ b/combiner/src/oqtopus_engine_combiner/mp_auto.py
@@ -272,17 +272,6 @@ class OptimalCircuitCombiner:
             dx <= POSITION_EPSILON < dy <= y_threshold + POSITION_EPSILON
         )
 
-        if is_horizontal_neighbor and is_vertical_neighbor:
-            logger.warning(
-                "two qubits are in the same position or very close.",
-                extra={
-                    "source_position": source_position,
-                    "target_position": target_position,
-                    "x_threshold": x_threshold,
-                    "y_threshold": y_threshold,
-                }
-            )
-
         return is_horizontal_neighbor or is_vertical_neighbor
 
     def combine_circuits_for_groups(
@@ -579,8 +568,8 @@ class OptimalCircuitCombiner:
         # If there is no used node, return empty set.
         if len(used_nodes) == 0:
             if len(exist_idle_nodes) > 0:
-                logger.warning(
-                    "exist idle nodes but no used nodes, this should not happen",
+                logger.info(
+                    "Exist idle nodes but no used nodes.",
                     extra={
                         "exist_idle_nodes": exist_idle_nodes,
                         "used_nodes": used_nodes,
@@ -595,8 +584,8 @@ class OptimalCircuitCombiner:
             for node in used_nodes:
                 idle_nodes.update(undirected_inferred_t.neighbors(node))
         else:
-            logger.warning(
-                "inferred topology is None, cannot calculate idle nodes before mapping"
+            logger.info(
+                "Inferred topology is None, cannot calculate idle nodes before mapping"
             )
 
         # remove used nodes and existing idle nodes from idle nodes
@@ -644,7 +633,7 @@ class OptimalCircuitCombiner:
             if value is not None:
                 assigned_endpoint_nodes.add(value)
             else:
-                logger.warning(
+                logger.info(
                     "Edge endpoint not in result mapping, this should not happen",
                     extra={
                         "edge_node": edge_node,
@@ -658,7 +647,7 @@ class OptimalCircuitCombiner:
             for node in assigned_endpoint_nodes:
                 idle_nodes.update(undirected_inferred_t.neighbors(node))
         else:
-            logger.warning(
+            logger.info(
                 "Inferred topology is None, cannot calculate idle nodes after mapping"
             )
 

--- a/combiner/tests/oqtopus_engine_combiner/test_app.py
+++ b/combiner/tests/oqtopus_engine_combiner/test_app.py
@@ -626,7 +626,7 @@ def test_custom_timed_rotating_file_handler_writes_log(tmp_path):
 
 
 def test_serve_starts_and_configures_server(tmp_path):
-    config = {"proto": {"max_workers": 2, "address": "[::]:59999"}}
+    config = {"proto": {"max_workers": 2, "address": "[::]:59999"}, "combiner": {"idle_qubits_insertion_enabled": True}}
     logging_config = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -639,7 +639,8 @@ def test_serve_starts_and_configures_server(tmp_path):
     config_path.write_text(yaml.dump(config))
     logging_path.write_text(yaml.dump(logging_config))
 
-    with patch("oqtopus_engine_combiner.app.grpc.server") as mock_grpc_server:
+    with patch("oqtopus_engine_combiner.app.grpc.server") as mock_grpc_server, \
+         patch("oqtopus_engine_combiner.app.add_CombinerServiceServicer_to_server") as mock_add_servicer:
         mock_server = MagicMock()
         mock_grpc_server.return_value = mock_server
         serve(str(config_path), str(logging_path))
@@ -647,10 +648,15 @@ def test_serve_starts_and_configures_server(tmp_path):
         mock_server.add_insecure_port.assert_called_once_with("[::]:59999")
         mock_server.start.assert_called_once()
         mock_server.wait_for_termination.assert_called_once()
+        
+        # Check that idle_qubits_insertion_enabled is True
+        mock_add_servicer.assert_called_once()
+        combiner_instance = mock_add_servicer.call_args[0][0]
+        assert combiner_instance._idle_qubits_insertion_enabled is True
 
 
 def test_serve_uses_defaults_when_config_missing_values(tmp_path):
-    config = {"proto": {}}
+    config = {"proto": {}, "combiner": {}}
     logging_config = {
         "version": 1,
         "disable_existing_loggers": False,
@@ -663,8 +669,15 @@ def test_serve_uses_defaults_when_config_missing_values(tmp_path):
     config_path.write_text(yaml.dump(config))
     logging_path.write_text(yaml.dump(logging_config))
 
-    with patch("oqtopus_engine_combiner.app.grpc.server") as mock_grpc_server:
+    with patch("oqtopus_engine_combiner.app.grpc.server") as mock_grpc_server,\
+         patch("oqtopus_engine_combiner.app.add_CombinerServiceServicer_to_server") as mock_add_servicer:
         mock_server = MagicMock()
         mock_grpc_server.return_value = mock_server
         serve(str(config_path), str(logging_path))
         mock_server.add_insecure_port.assert_called_once_with("[::]:52013")
+
+                # Check that idle_qubits_insertion_enabled is True
+        mock_add_servicer.assert_called_once()
+        combiner_instance = mock_add_servicer.call_args[0][0]
+        assert combiner_instance._idle_qubits_insertion_enabled is False
+    

--- a/combiner/tests/oqtopus_engine_combiner/test_mp_auto.py
+++ b/combiner/tests/oqtopus_engine_combiner/test_mp_auto.py
@@ -861,19 +861,19 @@ class TestOptimalCircuitCombiner:
 
         assert idle_nodes == set()
 
-    def test_calculate_idle_nodes_before_mapping_warning(self):
+    def test_calculate_idle_nodes_before_mapping_with_only_used_nodes(self):
         topology_json = make_linear_topology(5)
         topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
         job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
 
         combiner = OptimalCircuitCombiner()
-        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+        with patch("oqtopus_engine_combiner.mp_auto.logger.info") as mock_info:
             idle_nodes = combiner._calculate_idle_nodes_before_mapping(
                 set(), {0, 1}, topology, job.circuit_graph
             )
 
         assert idle_nodes == set()
-        mock_warning.assert_called_once_with(
+        mock_info.assert_called_once_with(
             "exist idle nodes but no used nodes, this should not happen",
             extra={
                 "exist_idle_nodes": {0, 1},
@@ -885,13 +885,13 @@ class TestOptimalCircuitCombiner:
         job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
 
         combiner = OptimalCircuitCombiner()
-        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+        with patch("oqtopus_engine_combiner.mp_auto.logger.info") as mock_info:
             idle_nodes = combiner._calculate_idle_nodes_before_mapping(
                 {0}, set(), None, job.circuit_graph
             )
 
         assert idle_nodes == set()
-        mock_warning.assert_called_once_with(
+        mock_info.assert_called_once_with(
             "inferred topology is None, cannot calculate idle nodes before mapping"
         )
 
@@ -964,13 +964,13 @@ class TestOptimalCircuitCombiner:
         job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
 
         combiner = OptimalCircuitCombiner()
-        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+        with patch("oqtopus_engine_combiner.mp_auto.logger.info") as mock_info:
             idle_nodes = combiner._calculate_idle_nodes_after_mapping(
                 set(), set(), topology, job.circuit_graph, {0: 0, 100: 1}
             )
 
         assert idle_nodes == set()
-        mock_warning.assert_called_once_with(
+        mock_info.assert_called_once_with(
             "Edge endpoint not in result mapping, this should not happen",
             extra={
                 "edge_node": 1,
@@ -982,13 +982,13 @@ class TestOptimalCircuitCombiner:
         job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
 
         combiner = OptimalCircuitCombiner()
-        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+        with patch("oqtopus_engine_combiner.mp_auto.logger.info") as mock_info:
             idle_nodes = combiner._calculate_idle_nodes_after_mapping(
                 set(), set(), None, job.circuit_graph, {0: 0, 1: 1}
             )
 
         assert idle_nodes == set()
-        mock_warning.assert_called_once_with(
+        mock_info.assert_called_once_with(
             "Inferred topology is None, cannot calculate idle nodes after mapping"
         )
 

--- a/combiner/tests/oqtopus_engine_combiner/test_mp_auto.py
+++ b/combiner/tests/oqtopus_engine_combiner/test_mp_auto.py
@@ -1,15 +1,18 @@
 import sys
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.joinpath("src")))
 
 import networkx as nx  # type: ignore[import-untyped]
+import pytest
 from qiskit import QuantumCircuit  # type: ignore[import-untyped]
 
 from oqtopus_engine_combiner.mp_auto import (  # type: ignore[import-untyped]
     JobWithCircuitGraph,
     OptimalCircuitCombiner,
+    POSITION_EPSILON,
 )
 
 
@@ -523,7 +526,8 @@ class TestOptimalCircuitCombiner:
         topology = OptimalCircuitCombiner.create_topology_graph(make_linear_topology(5))
         job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
 
-        results = OptimalCircuitCombiner._find_nonoverlapping_subgraphs_with_t_nodes(
+        combiner = OptimalCircuitCombiner()
+        results = combiner._find_nonoverlapping_subgraphs_with_t_nodes(
             topology, [job]
         )
 
@@ -547,7 +551,8 @@ class TestOptimalCircuitCombiner:
             JobWithCircuitGraph(job_id="job-5", program=SIMPLE_1Q_QASM),
         ]
 
-        results = OptimalCircuitCombiner._find_nonoverlapping_subgraphs_with_t_nodes(
+        combiner = OptimalCircuitCombiner()
+        results = combiner._find_nonoverlapping_subgraphs_with_t_nodes(
             topology, jobs
         )
 
@@ -592,7 +597,8 @@ class TestOptimalCircuitCombiner:
             JobWithCircuitGraph(job_id="job-3", program=SIMPLE_1Q_QASM),
         ]
 
-        results = OptimalCircuitCombiner._find_nonoverlapping_subgraphs_with_t_nodes(
+        combiner = OptimalCircuitCombiner()
+        results = combiner._find_nonoverlapping_subgraphs_with_t_nodes(
             topology, jobs
         )
 
@@ -627,7 +633,8 @@ class TestOptimalCircuitCombiner:
         )
         job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
 
-        results = OptimalCircuitCombiner._find_nonoverlapping_subgraphs_with_t_nodes(
+        combiner = OptimalCircuitCombiner()
+        results = combiner._find_nonoverlapping_subgraphs_with_t_nodes(
             topology, [job]
         )
 
@@ -643,6 +650,407 @@ class TestOptimalCircuitCombiner:
 
         # Should not raise
         OptimalCircuitCombiner._draw_graph(topology, topology_json, matches, filename)
+
+    # --- create_device_grid_graph ---
+
+    @pytest.mark.parametrize(
+        ("topology_json", "expected_nodes", "expected_edges"),
+        [
+            (make_linear_topology(5), 5, 4),
+            (make_grid_topology(3, 3), 9, 12),
+            (make_grid_topology_with_defects(), 64, 112),
+        ],
+        ids=["linear", "complete_3x3_grid", "recover_defects_8x8"],
+    )
+    def test_create_device_grid_graph_shape(
+        self,
+        topology_json: dict[str, Any],
+        expected_nodes: int,
+        expected_edges: int,
+    ):
+        graph = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+
+        assert isinstance(graph, nx.Graph)
+        assert graph.number_of_nodes() == expected_nodes
+        assert graph.number_of_edges() == expected_edges
+
+    def test_create_device_grid_graph_linear_adjacency(self):
+        topology_json = make_linear_topology(5)
+
+        graph = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+
+        assert graph.has_edge(0, 1)
+        assert graph.has_edge(1, 2)
+        assert graph.has_edge(2, 3)
+        assert graph.has_edge(3, 4)
+
+    def test_create_device_grid_graph_orthogonal_only(self):
+        topology_json = make_grid_topology(3, 3)
+
+        graph = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+
+        assert graph.has_edge(0, 1)
+        assert graph.has_edge(0, 3)
+        assert not graph.has_edge(0, 4)
+
+    def test_create_device_grid_graph_recovers_defect_edges(self):
+        topology_json = make_grid_topology_with_defects()
+
+        graph = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+
+        assert graph.has_edge(27, 19)
+        assert graph.has_edge(36, 37)
+
+    def test_create_device_grid_graph_single_qubit(self):
+        topology_json = {
+            "qubits": [{"id": 0, "position": {"x": 0.0, "y": 0.0}}],
+            "couplings": [],
+        }
+
+        graph = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+
+        assert graph.number_of_nodes() == 1
+        assert graph.number_of_edges() == 0
+
+    # --- _infer_grid_thresholds ---
+
+    @pytest.mark.parametrize(
+        ("positions", "couplings", "expected_x", "expected_y"),
+        [
+            (
+                {0: (0.0, 0.0), 1: (1.0, 0.0)},
+                [{"control": 0, "target": 1}],
+                1.0,
+                0.0,
+            ),
+            (
+                {0: (0.0, 0.0), 1: (1.0, 0.0), 2: (0.0, 2.0)},
+                [{"control": 0, "target": 1}, {"control": 0, "target": 2}],
+                1.0,
+                2.0,
+            ),
+            (
+                {0: (0.0, 0.0), 1: (1.0, 0.0)},
+                [{"control": 0, "target": 1}, {"control": 0, "target": 999}],
+                1.0,
+                0.0,
+            ),
+            (
+                {0: (0.5, 0.5), 1: (1.7, 0.5)},
+                [{"control": 0, "target": 1}],
+                1.2,
+                0.0,
+            ),
+            (
+                {0: (0.0, 0.0), 1: (1.0, 0.0)},
+                [],
+                0.0,
+                0.0,
+            ),
+        ],
+        ids=[
+            "single_coupling",
+            "multiple_couplings_max",
+            "missing_positions_skipped",
+            "floating_positions",
+            "no_couplings",
+        ],
+    )
+    def test_infer_grid_thresholds(
+        self,
+        positions: dict[int, tuple[float, float]],
+        couplings: list[dict[str, Any]],
+        expected_x: float,
+        expected_y: float,
+    ):
+        x_threshold, y_threshold = OptimalCircuitCombiner._infer_grid_thresholds(
+            positions,
+            couplings,
+        )
+
+        assert x_threshold == pytest.approx(expected_x)
+        assert y_threshold == pytest.approx(expected_y)
+
+    # --- _is_orthogonal_neighbor ---
+
+    @pytest.mark.parametrize(
+        (
+            "source_position",
+            "target_position",
+            "x_threshold",
+            "y_threshold",
+            "expected",
+        ),
+        [
+            ((0.0, 0.0), (1.0, 0.0), 1.0, 1.0, True),
+            ((0.0, 0.0), (0.0, 2.0), 1.0, 2.0, True),
+            ((0.0, 0.0), (1.0, 1.0), 1.0, 1.0, False),
+            ((0.0, 0.0), (1.0, POSITION_EPSILON / 2), 1.0, 1.0, True),
+            ((0.0, 0.0), (1.0, POSITION_EPSILON * 2), 1.0, 1.0, False),
+            ((0.0, 0.0), (2.0, 0.0), 1.0, 1.0, False),
+            ((0.0, 0.0), (1.0 + POSITION_EPSILON / 2, 0.0), 1.0, 1.0, True),
+        ],
+        ids=[
+            "horizontal",
+            "vertical",
+            "diagonal_false",
+            "epsilon_within",
+            "epsilon_outside",
+            "exceeds_threshold",
+            "threshold_plus_epsilon_allowed",
+        ],
+    )
+    def test_is_orthogonal_neighbor(
+        self,
+        source_position: tuple[float, float],
+        target_position: tuple[float, float],
+        x_threshold: float,
+        y_threshold: float,
+        expected: bool,
+    ):
+        result = OptimalCircuitCombiner._is_orthogonal_neighbor(
+            source_position,
+            target_position,
+            x_threshold=x_threshold,
+            y_threshold=y_threshold,
+        )
+
+        assert result is expected
+
+    def test_is_orthogonal_neighbor_is_symmetric(self):
+        result_1 = OptimalCircuitCombiner._is_orthogonal_neighbor(
+            (0.0, 0.0),
+            (1.0, 0.0),
+            x_threshold=1.0,
+            y_threshold=1.0,
+        )
+        result_2 = OptimalCircuitCombiner._is_orthogonal_neighbor(
+            (1.0, 0.0),
+            (0.0, 0.0),
+            x_threshold=1.0,
+            y_threshold=1.0,
+        )
+
+        assert result_1 is True
+        assert result_2 is True
+
+    # --- _calculate_idle_nodes_before_mapping ---
+
+    def test_calculate_idle_nodes_before_mapping_with_non_edge_of_g(self):
+        topology_json = make_linear_topology(5)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_1Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+            set(), set(), topology, job.circuit_graph
+        )
+
+        assert idle_nodes == set()
+
+        
+    def test_calculate_idle_nodes_before_mapping_with_empty_exist_idle_nodes_and_used_nodes(self):
+        topology_json = make_linear_topology(5)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+            set(), set(), topology, job.circuit_graph
+        )
+
+        assert idle_nodes == set()
+
+    def test_calculate_idle_nodes_before_mapping_warning(self):
+        topology_json = make_linear_topology(5)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+            idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+                set(), {0, 1}, topology, job.circuit_graph
+            )
+
+        assert idle_nodes == set()
+        mock_warning.assert_called_once_with(
+            "exist idle nodes but no used nodes, this should not happen",
+            extra={
+                "exist_idle_nodes": {0, 1},
+                "used_nodes": set(),
+            },
+        )
+
+    def test_calculate_idle_nodes_before_mapping_with_none_inferred_topology(self):
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+            idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+                {0}, set(), None, job.circuit_graph
+            )
+
+        assert idle_nodes == set()
+        mock_warning.assert_called_once_with(
+            "inferred topology is None, cannot calculate idle nodes before mapping"
+        )
+
+    def test_calculate_idle_nodes_before_mapping_with_only_used_nodes(self):
+        topology_json = make_grid_topology(3, 4)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+            {5, 6}, set(), topology, job.circuit_graph
+        )
+
+        assert idle_nodes == {1, 2, 4, 7, 9, 10}
+
+    def test_calculate_idle_nodes_before_mapping_with_used_nodes_and_exist_idle_nodes(self):
+        topology_json = make_grid_topology(3, 4)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+            {5, 6}, {1, 2, 4, 7, 9, 10}, topology, job.circuit_graph
+        )
+
+        assert idle_nodes == set()
+
+    def test_calculate_idle_nodes_before_mapping_with_only_used_nodes_and_defects_topology(self):
+        topology_json = make_grid_topology_with_defects()
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+            {19, 36}, set(), topology, job.circuit_graph
+        )
+
+        assert idle_nodes == {11, 18, 20, 27, 28, 35, 37, 44}
+
+    def test_calculate_idle_nodes_before_mapping_with_used_nodes_and_exist_idle_nodes_and_defects_topology(self):
+        topology_json = make_grid_topology_with_defects()
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_before_mapping(
+            {19, 35, 36}, {27, 28, 34, 37, 43, 44}, topology, job.circuit_graph
+        )
+
+        assert idle_nodes == {11, 18, 20}
+
+    # --- _calculate_idle_nodes_after_mapping ---
+
+    def test_calculate_idle_nodes_after_mapping_with_non_edge_of_g(self):
+        topology_json = make_linear_topology(5)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_1Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+            set(), set(), topology, job.circuit_graph, {1: 1}
+        )
+
+        assert idle_nodes == set()
+
+    def test_calculate_idle_nodes_after_mapping_edge_endpoint_not_in_result_mapping(self):
+        topology_json = make_linear_topology(5)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+            idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+                set(), set(), topology, job.circuit_graph, {0: 0, 100: 1}
+            )
+
+        assert idle_nodes == set()
+        mock_warning.assert_called_once_with(
+            "Edge endpoint not in result mapping, this should not happen",
+            extra={
+                "edge_node": 1,
+                "result_mapping": {0: 0, 100: 1},
+            },
+        )
+
+    def test_calculate_idle_nodes_after_mapping_with_none_inferred_topology(self):
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        with patch("oqtopus_engine_combiner.mp_auto.logger.warning") as mock_warning:
+            idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+                set(), set(), None, job.circuit_graph, {0: 0, 1: 1}
+            )
+
+        assert idle_nodes == set()
+        mock_warning.assert_called_once_with(
+            "Inferred topology is None, cannot calculate idle nodes after mapping"
+        )
+
+    def test_calculate_idle_nodes_after_mapping_with_non_used_nodes_and_exist_idle_nodes(self):
+        topology_json = make_grid_topology(3, 4)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+            set(), set(), topology, job.circuit_graph, {0: 0, 1: 1}
+        )
+
+        assert idle_nodes == {2, 4, 5}
+
+    def test_calculate_idle_nodes_after_mapping_with_only_used_nodes(self):
+        topology_json = make_grid_topology(3, 4)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+            {6}, set(), topology, job.circuit_graph, {0: 0, 1: 1}
+        )
+
+        assert idle_nodes == {2, 4, 5}
+
+    def test_calculate_idle_nodes_after_mapping_with_used_nodes_and_exist_idle_nodes(self):
+        topology_json = make_grid_topology(3, 4)
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+            {8, 9}, {4, 5, 10}, topology, job.circuit_graph, {0: 0, 1: 1}
+        )
+
+        assert idle_nodes == {2}
+
+    def test_calculate_idle_nodes_after_mapping_with_only_used_nodes_on_defects_topology(self):
+        topology_json = make_grid_topology_with_defects()
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+            {17}, set(), topology, job.circuit_graph, {0: 18, 1: 19}
+        )
+
+        assert idle_nodes == {10, 11, 20, 26, 27}
+    
+    def test_calculate_idle_nodes_after_mapping_with_used_nodes_and_exist_idle_nodes_on_defects_topology(self):
+        topology_json = make_grid_topology_with_defects()
+        topology = OptimalCircuitCombiner.create_device_grid_graph(topology_json)
+        job = JobWithCircuitGraph(job_id="job-1", program=SIMPLE_2Q_QASM)
+
+        combiner = OptimalCircuitCombiner()
+        idle_nodes = combiner._calculate_idle_nodes_after_mapping(
+            {21, 22}, {13, 14, 20, 23, 29, 30}, topology, job.circuit_graph, {0: 18, 1: 19}
+        )
+
+        assert idle_nodes == {10, 11, 17, 26, 27}
 
     # --- End-to-end: assign + combine ---
 


### PR DESCRIPTION
This PR enables consideration of idle qubits (buffer qubits) when combining quantum circuits in multi-programming auto.
This feature can be toggled on or off through configuration when starting the combiner.