### PR TITLE
Restore SSE log upload behavior

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -125,6 +125,7 @@ di_container:
         container_work_path: ${SSE_CONTAINER_PATH, "/sse"}
         userprogram_name: ${SSE_USER_PROGRAM_NAME, "userprogram.py"}
         result_file_name: ${SSE_RESULT_NAME, "result.json"}
+        log_file_name: ${SSE_LOG_NAME, "sse_runtime.log"}
         container_image: ${SSE_CONTAINER_IMAGE, "sse-v2/python3.13:latest"}
         container_disk_quota: ${SSE_CONTAINER_DISK_QUOTA, 67108864}
         container_memory: ${SSE_CONTAINER_MEMORY, 268435456}

--- a/core/src/oqtopus_engine_core/framework/job_repository.py
+++ b/core/src/oqtopus_engine_core/framework/job_repository.py
@@ -82,6 +82,7 @@ class JobRepository(ABC):
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
     ) -> None:
         """Upload job output data to the backing storage.
 
@@ -90,6 +91,7 @@ class JobRepository(ABC):
             presigned_url: Presigned URL for upload.
             data: Data to be uploaded.
             arcname_ext: Data file extension to be zipped, e.g. `.json`.
+            arcname: Override filename to store inside the uploaded zip archive.
 
         Raises:
             NotImplementedError: If not implemented in subclass.
@@ -101,12 +103,13 @@ class JobRepository(ABC):
         raise NotImplementedError(message)
 
     @abstractmethod
-    async def upload_job_output_nowait(
+    async def upload_job_output_nowait(  # noqa: PLR0913
         self,
         job: Job,
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
         *,
         preserve_order: bool = True,
     ) -> None:
@@ -117,6 +120,7 @@ class JobRepository(ABC):
             presigned_url: Presigned URL for upload.
             data: Data to be uploaded.
             arcname_ext: Data file extension to be zipped, e.g. `.json`.
+            arcname: Override filename to store inside the uploaded zip archive.
             preserve_order:
                 If ``True`` (default), operations targeting the same ``job_id``
                 are executed sequentially so that updates cannot overtake each

--- a/core/src/oqtopus_engine_core/repositories/null_job_repository.py
+++ b/core/src/oqtopus_engine_core/repositories/null_job_repository.py
@@ -90,6 +90,7 @@ class NullJobRepository(JobRepository):
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
     ) -> None:
         """Log and discard the upload request."""
         self._log_noop(
@@ -98,15 +99,17 @@ class NullJobRepository(JobRepository):
             job_type=job.job_type,
             key=getattr(getattr(presigned_url, "fields", None), "key", None),
             arcname_ext=arcname_ext,
+            arcname=arcname,
             data_type=type(data).__name__,
         )
 
-    async def upload_job_output_nowait(
+    async def upload_job_output_nowait(  # noqa: PLR0913
         self,
         job: Job,
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
         *,
         preserve_order: bool = True,
     ) -> None:
@@ -117,6 +120,7 @@ class NullJobRepository(JobRepository):
             job_type=job.job_type,
             key=getattr(getattr(presigned_url, "fields", None), "key", None),
             arcname_ext=arcname_ext,
+            arcname=arcname,
             preserve_order=preserve_order,
             data_type=type(data).__name__,
         )

--- a/core/src/oqtopus_engine_core/repositories/oqtopus_cloud_job_repository.py
+++ b/core/src/oqtopus_engine_core/repositories/oqtopus_cloud_job_repository.py
@@ -450,6 +450,7 @@ class OqtopusCloudJobRepository(JobRepository):
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
     ) -> None:
         """Upload job output data as a .zip file to cloud storage."""
 
@@ -461,6 +462,7 @@ class OqtopusCloudJobRepository(JobRepository):
                 presigned_url=presigned_url,
                 data=data,
                 arcname_ext=arcname_ext,
+                arcname=arcname,
                 max_size=self._max_file_size,
                 proxies=proxies,
                 timeout_s=self._file_op_timeout_seconds,
@@ -500,12 +502,13 @@ class OqtopusCloudJobRepository(JobRepository):
 
         job.output_files.append(presigned_url.fields.key)
 
-    async def upload_job_output_nowait(
+    async def upload_job_output_nowait(  # noqa: PLR0913
         self,
         job: Job,
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
         *,
         preserve_order: bool = True,
     ) -> None:
@@ -519,6 +522,7 @@ class OqtopusCloudJobRepository(JobRepository):
                         presigned_url,
                         data,
                         arcname_ext,
+                        arcname,
                     ),
                 )
             )
@@ -529,6 +533,7 @@ class OqtopusCloudJobRepository(JobRepository):
                     presigned_url,
                     data,
                     arcname_ext,
+                    arcname,
                 )
             )
 

--- a/core/src/oqtopus_engine_core/steps/job_repository_update_step.py
+++ b/core/src/oqtopus_engine_core/steps/job_repository_update_step.py
@@ -15,6 +15,13 @@ class JobRepositoryUpdateStep(Step):
             "JobRepositoryUpdateStep was initialized",
         )
 
+    @staticmethod
+    def _get_sse_log_file_name(gctx: GlobalContext) -> str | None:
+        registry = gctx.config.get("di_container", {}).get("registry", {})
+        sse_step = registry.get("sse_step", {})
+        runner_settings = sse_step.get("runner_settings", {})
+        return runner_settings.get("log_file_name")
+
     async def pre_process(
         self,
         gctx: GlobalContext,
@@ -32,7 +39,7 @@ class JobRepositoryUpdateStep(Step):
 
         """
 
-    async def post_process(  # noqa: PLR6301
+    async def post_process(
         self,
         gctx: GlobalContext,
         jctx: JobContext,  # noqa: ARG002
@@ -46,6 +53,9 @@ class JobRepositoryUpdateStep(Step):
             gctx: The global context.
             jctx: The job context.
             job: The job object.
+
+        Raises:
+            ValueError: If the job result or SSE log is missing.
 
         """
         items = ["result"]
@@ -74,7 +84,8 @@ class JobRepositoryUpdateStep(Step):
                 job=job,
                 presigned_url=urls[1],
                 data=job.sse_log,
-                arcname_ext=".log"
+                arcname_ext=".log",
+                arcname=self._get_sse_log_file_name(gctx),
             )
 
         job.status = "succeeded"

--- a/core/src/oqtopus_engine_core/steps/sse_step.py
+++ b/core/src/oqtopus_engine_core/steps/sse_step.py
@@ -52,6 +52,7 @@ class SseStep(Step):
 
         Raises:
             RuntimeError: If the SSE run fails.
+            ValueError: If the SSE program is missing from the job.
 
         """
         if job.job_type != "sse":

--- a/core/src/oqtopus_engine_core/utils/storage_util.py
+++ b/core/src/oqtopus_engine_core/utils/storage_util.py
@@ -85,6 +85,7 @@ class OqtopusStorage:
         presigned_url: JobsJobInfoUploadPresignedURL,
         data: dict[str, Any] | str,
         arcname_ext: str = "",
+        arcname: str | None = None,
         max_size: int | None = None,
         proxies: dict[str, str] | None = None,
         timeout_s: int = DEFAULT_TIMEOUT_S,
@@ -95,6 +96,7 @@ class OqtopusStorage:
             presigned_url (JobsJobInfoUploadPresignedURL): presigned URL for upload
             data (dict[str, Any]): data to upload
             arcname_ext: data file extension to be zipped e.g. `.json`
+            arcname: override filename to store inside the zip archive
             max_size: maximum size of the .zip file in bytes
             proxies: connection proxies to use
             timeout_s: operation timeout in seconds
@@ -109,9 +111,14 @@ class OqtopusStorage:
                 with ZipFile(
                     file=zip_buffer, mode="w", compression=ZIP_DEFLATED
                 ) as zip_arch:
+                    archive_name = (
+                        arcname
+                        if arcname is not None
+                        else f"{Path(zip_buffer.name).stem}{arcname_ext}"
+                    )
                     zip_arch.writestr(
-                        zinfo_or_arcname=f"{Path(zip_buffer.name).stem}{arcname_ext}",
-                        data=json.dumps(data),
+                        zinfo_or_arcname=archive_name,
+                        data=data if isinstance(data, str) else json.dumps(data),
                     )
                 zip_buffer.seek(0)
 

--- a/core/tests/oqtopus_engine_core/steps/test_job_repository_update_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_job_repository_update_step.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from oqtopus_engine_core.framework import Job, JobContext, JobResult, SamplingResult
+from oqtopus_engine_core.interfaces.oqtopus_cloud import (
+    JobsJobInfoUploadPresignedURL,
+    JobsJobInfoUploadPresignedURLFields,
+)
+from oqtopus_engine_core.steps.job_repository_update_step import JobRepositoryUpdateStep
+
+
+def _make_job() -> Job:
+    return Job(
+        job_id="job-1",
+        name="sse",
+        description="",
+        device_id="qulacs",
+        shots=1,
+        job_type="sse",
+        input="input.zip",
+        transpiler_info={},
+        simulator_info={},
+        mitigation_info={},
+        status="running",
+        result=JobResult(sampling=SamplingResult(counts={"00": 1})),
+        sse_log="line 1\nline 2\n",
+        output_files=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_process_uses_configured_sse_log_filename() -> None:
+    step = JobRepositoryUpdateStep()
+    job = _make_job()
+    jctx = JobContext()
+    gctx = SimpleNamespace(
+        config={
+            "di_container": {
+                "registry": {
+                    "sse_step": {
+                        "runner_settings": {
+                            "log_file_name": "ssecontainer.log"
+                        }
+                    }
+                }
+            }
+        },
+        job_repository=SimpleNamespace(
+            get_job_upload_url=AsyncMock(
+                return_value=[
+                    JobsJobInfoUploadPresignedURL(
+                        url="null://upload",
+                        fields=JobsJobInfoUploadPresignedURLFields(
+                            key="job-1/result"
+                        ),
+                    ),
+                    JobsJobInfoUploadPresignedURL(
+                        url="null://upload",
+                        fields=JobsJobInfoUploadPresignedURLFields(
+                            key="job-1/sse_log"
+                        ),
+                    ),
+                ]
+            ),
+            upload_job_output=AsyncMock(),
+            update_job_status_nowait=AsyncMock(),
+        )
+    )
+
+    await step.post_process(gctx, jctx, job)
+
+    assert gctx.job_repository.upload_job_output.await_count == 2
+    gctx.job_repository.upload_job_output.assert_any_await(
+        job=job,
+        presigned_url=gctx.job_repository.get_job_upload_url.return_value[1],
+        data=job.sse_log,
+        arcname_ext=".log",
+        arcname="ssecontainer.log",
+    )


### PR DESCRIPTION
## Summary
This PR restores SSE log upload behavior so that SSE logs are uploaded as plain text, preserve real newlines after extraction, and use a configurable filename from engine config. The default filename remains sse_runtime.log.

## Changes
- support overriding uploaded zip entry names
- use the configured SSE log filename during SSE log upload
- preserve plain text SSE log content during upload
- add a regression test for SSE log filename handling

## Validation
- ran the SSE log filename regression test
- ran ruff on the touched files
