### PR TITLE
fix: add request timeout to OqtopusCloud job/device API calls

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -55,6 +55,7 @@ di_container:
       url: ${JOB_REPOSITORY_URL, "http://localhost:8888"}
       api_key: ${JOB_REPOSITORY_API_KEY, ""}
       workers: ${JOB_REPOSITORY_WORKERS, 10}
+      api_request_timeout_seconds: ${JOB_API_REQUEST_TIMEOUT_SECONDS, 10}
       file_op_timeout_seconds: ${JOB_FILE_OP_TIMEOUT_SECONDS, 60}
       max_file_size: ${MAX_FILE_SIZE, 10485760}
 
@@ -66,6 +67,7 @@ di_container:
       url: ${DEVICE_REPOSITORY_URL, "http://localhost:8888"}
       api_key: ${DEVICE_REPOSITORY_API_KEY, ""}
       workers: ${DEVICE_REPOSITORY_WORKERS, 1}
+      api_request_timeout_seconds: ${DEVICE_REPOSITORY_API_REQUEST_TIMEOUT_SECONDS, 10}
 
     # buffer configurations
     buffer:

--- a/core/src/oqtopus_engine_core/repositories/oqtopus_cloud_device_repository.py
+++ b/core/src/oqtopus_engine_core/repositories/oqtopus_cloud_device_repository.py
@@ -46,6 +46,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
         api_key: str = "",
         proxy: str | None = None,
         workers: int = 5,
+        api_request_timeout_seconds: int = 10,
     ) -> None:
         """Initialize the device repository with the API URL and interval.
 
@@ -54,6 +55,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
             api_key: The API key for authentication.
             proxy: The proxy URL for the API request.
             workers: The number of concurrent workers to use for API requests.
+            api_request_timeout_seconds: Timeout for Devices API HTTP requests.
 
         """
         super().__init__()
@@ -69,6 +71,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
         )
         self._devices_api = DevicesApi(api_client=api_client)
         self._sem = asyncio.Semaphore(workers)
+        self._api_request_timeout_seconds = api_request_timeout_seconds
 
         logger.info(
             "OqtopusCloudDeviceRepository was initialized",
@@ -76,6 +79,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
                 "url": url,
                 "proxy": proxy,
                 "workers": workers,
+                "api_request_timeout_seconds": api_request_timeout_seconds,
             },
         )
 
@@ -143,6 +147,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
             return self._devices_api.patch_device_with_http_info(
                 device_id=device.device_id,
                 body=body,
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         extra: dict[str, Any] = {"device_id": device.device_id}
@@ -187,6 +192,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
             return self._devices_api.patch_device_status_with_http_info(
                 device_id=device.device_id,
                 body=body,
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         logger.info(
@@ -228,6 +234,7 @@ class OqtopusCloudDeviceRepository(DeviceRepository):
             return self._devices_api.patch_device_info_with_http_info(
                 device_id=device.device_id,
                 body=body,
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         extra: dict[str, Any] = {"device_id": device.device_id}

--- a/core/src/oqtopus_engine_core/repositories/oqtopus_cloud_job_repository.py
+++ b/core/src/oqtopus_engine_core/repositories/oqtopus_cloud_job_repository.py
@@ -32,6 +32,7 @@ class OqtopusCloudJobRepository(JobRepository):
         api_key: str = "",
         proxy: str | None = None,
         workers: int = 5,
+        api_request_timeout_seconds: int = 10,
         file_op_timeout_seconds: int = 60,
         max_file_size: int = 10485760,
     ) -> None:
@@ -42,6 +43,7 @@ class OqtopusCloudJobRepository(JobRepository):
             api_key: The API key for authentication.
             proxy: The proxy URL for the API request.
             workers: The number of concurrent workers to use for API requests.
+            api_request_timeout_seconds: Timeout for Jobs API HTTP requests.
             file_op_timeout_seconds: Timeout for file upload and download.
             max_file_size: Maximum allowed size for uploaded ZIP payloads.
 
@@ -69,6 +71,7 @@ class OqtopusCloudJobRepository(JobRepository):
         self._job_tails_lock = asyncio.Lock()
 
         self._proxy = proxy
+        self._api_request_timeout_seconds = api_request_timeout_seconds
         self._file_op_timeout_seconds = file_op_timeout_seconds
         self._max_file_size = max_file_size
 
@@ -78,6 +81,7 @@ class OqtopusCloudJobRepository(JobRepository):
                 "url": url,
                 "proxy": proxy,
                 "workers": workers,
+                "api_request_timeout_seconds": api_request_timeout_seconds,
                 "file_op_timeout_seconds": file_op_timeout_seconds,
             },
         )
@@ -305,6 +309,7 @@ class OqtopusCloudJobRepository(JobRepository):
                 device_id=device_id,
                 status=status,
                 limit=limit,
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         extra: dict[str, Any] = {
@@ -358,7 +363,9 @@ class OqtopusCloudJobRepository(JobRepository):
 
         def _call() -> tuple[list[JobsJobInfoUploadPresignedURL], int, dict]:
             return self._jobs_api.get_upload_with_http_info(
-                job_id=job.job_id, items=",".join(items)
+                job_id=job.job_id,
+                items=",".join(items),
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         extra: dict[str, Any] = {
@@ -564,6 +571,7 @@ class OqtopusCloudJobRepository(JobRepository):
             return self._jobs_api.patch_job_with_http_info(
                 job_id=job.job_id,
                 body=body,
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         extra: dict[str, Any] = {
@@ -648,6 +656,7 @@ class OqtopusCloudJobRepository(JobRepository):
             return self._jobs_api.update_job_transpiler_info_with_http_info(
                 job_id=job.job_id,
                 body=body,
+                _request_timeout=self._api_request_timeout_seconds,
             )
 
         extra: dict[str, Any] = {

--- a/core/tests/oqtopus_engine_core/repositories/test_oqtopus_cloud_job_repository.py
+++ b/core/tests/oqtopus_engine_core/repositories/test_oqtopus_cloud_job_repository.py
@@ -269,6 +269,31 @@ async def test_enqueue_and_run_continues_after_coroutine_failure():
 
 
 # ---------------------------------------------------------------------------
+# get_jobs – api_request_timeout_seconds is passed to the generated client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_jobs_passes_api_request_timeout_seconds():
+    """get_jobs must forward api_request_timeout_seconds as _request_timeout."""
+    with patch(
+        "oqtopus_engine_core.repositories.oqtopus_cloud_job_repository.JobsApi"
+    ) as mock_jobs_api_cls, patch(
+        "oqtopus_engine_core.repositories.oqtopus_cloud_job_repository.ApiClient"
+    ), patch(
+        "oqtopus_engine_core.repositories.oqtopus_cloud_job_repository.Configuration"
+    ):
+        mock_jobs_api = mock_jobs_api_cls.return_value
+        mock_jobs_api.get_jobs_with_http_info.return_value = ([], 200, {})
+
+        repo = OqtopusCloudJobRepository(workers=2, api_request_timeout_seconds=15)
+        await repo.get_jobs(device_id="test-device")
+
+        _, kwargs = mock_jobs_api.get_jobs_with_http_info.call_args
+        assert kwargs["_request_timeout"] == 15
+
+
+# ---------------------------------------------------------------------------
 # _enqueue_and_run – failed coroutine is logged
 # ---------------------------------------------------------------------------
 

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -56,6 +56,9 @@ di_container:
       url: ${JOB_REPOSITORY_URL, "http://localhost:8888"}
       api_key: ${JOB_REPOSITORY_API_KEY, ""}
       workers: ${JOB_REPOSITORY_WORKERS, 10}
+      api_request_timeout_seconds: ${JOB_API_REQUEST_TIMEOUT_SECONDS, 10}
+      file_op_timeout_seconds: ${JOB_FILE_OP_TIMEOUT_SECONDS, 60}
+      max_file_size: ${MAX_FILE_SIZE, 10485760}
 
     _device_repository:
       _target_: oqtopus_engine_core.repositories.NullDeviceRepository
@@ -65,6 +68,7 @@ di_container:
       url: ${DEVICE_REPOSITORY_URL, "http://localhost:8888"}
       api_key: ${DEVICE_REPOSITORY_API_KEY, ""}
       workers: ${DEVICE_REPOSITORY_WORKERS, 1}
+      api_request_timeout_seconds: ${DEVICE_REPOSITORY_API_REQUEST_TIMEOUT_SECONDS, 10}
 
     # buffer configurations
     buffer:


### PR DESCRIPTION
This pull request introduces configurable API request timeouts for both the job and device repositories, ensuring that HTTP requests to these APIs do not hang indefinitely and can be tuned via configuration. The changes add the `api_request_timeout_seconds` parameter throughout the configuration files, repository classes, and relevant API calls, and include a test to verify correct forwarding of this parameter.

**Configuration enhancements:**

* Added `api_request_timeout_seconds` to the job and device repository sections in both `core/config/config.yaml` and `docs/usage/config.md`, allowing the timeout to be set via environment variables. [[1]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970R58) [[2]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970R70) [[3]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aR59-R61) [[4]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aR71)

**Repository class updates:**

* Updated `OqtopusCloudJobRepository` and `OqtopusCloudDeviceRepository` constructors to accept and store the `api_request_timeout_seconds` parameter, and included it in logging for easier debugging. [[1]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R35) [[2]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R46) [[3]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R74) [[4]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R84) [[5]](diffhunk://#diff-c75ca98aa34caf4dc1ef46df4ac96bcd2e2565f6171c185e6342ce3c6f7685deR49) [[6]](diffhunk://#diff-c75ca98aa34caf4dc1ef46df4ac96bcd2e2565f6171c185e6342ce3c6f7685deR58) [[7]](diffhunk://#diff-c75ca98aa34caf4dc1ef46df4ac96bcd2e2565f6171c185e6342ce3c6f7685deR74-R82)

**API call modifications:**

* Passed `_request_timeout=self._api_request_timeout_seconds` to all relevant HTTP API calls in both job and device repositories, ensuring the configured timeout is respected in all operations. [[1]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R312) [[2]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333L361-R368) [[3]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R574) [[4]](diffhunk://#diff-f3fa41db7b76d98c6b13bc8fba41bd4a06c1470d5468eacc54d7db770c815333R659) [[5]](diffhunk://#diff-c75ca98aa34caf4dc1ef46df4ac96bcd2e2565f6171c185e6342ce3c6f7685deR150) [[6]](diffhunk://#diff-c75ca98aa34caf4dc1ef46df4ac96bcd2e2565f6171c185e6342ce3c6f7685deR195) [[7]](diffhunk://#diff-c75ca98aa34caf4dc1ef46df4ac96bcd2e2565f6171c185e6342ce3c6f7685deR237)

**Testing:**

* Added a test (`test_get_jobs_passes_api_request_timeout_seconds`) to verify that the `api_request_timeout_seconds` parameter is correctly forwarded as `_request_timeout` to the generated API client in job repository operations.