### PR TITLE
feat: make job buffer selectable via JOB_BUFFER env var

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -10,10 +10,10 @@ pipeline_executor:
     - estimator_step
     - ro_error_mitigation_step
     - mp_auto_combining_step
-    - buffer
+    - ${JOB_BUFFER, buffer}
     - sse_step
     - device_gateway_step
-  job_buffer: buffer
+  job_buffer: ${JOB_BUFFER, buffer}
   exception_handler: pipeline_exception_handler
 
 # Dependency Injection Container Configuration
@@ -38,7 +38,7 @@ di_container:
 
     device_fetcher:
       _target_: oqtopus_engine_core.fetchers.DeviceGatewayFetcher
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
       grpc_options: *grpc_options
       initial_interval_seconds: ${DEVICE_FETCHER_INITIAL_INTERVAL_SECONDS, 10}
       initial_backoff_max_seconds: ${DEVICE_FETCHER_INITIAL_BACKOFF_MAX_SECONDS, 60}
@@ -73,9 +73,9 @@ di_container:
     buffer:
       _target_: oqtopus_engine_core.buffers.QueueBuffer
 
-    _buffer:
+    buffer_mp_auto_combining:
       _target_: oqtopus_engine_core.mp.auto_combining.MpAutoCombiningBuffer
-      combiner_address: ${COMBINER_ADDRESS, "localhost:52013"}
+      combiner_address: ${COMBINER_ADDRESS, "localhost:51013"}
       grpc_options: *grpc_options
       monitor_interval_seconds: ${MP_AUTO_BUFFER_MONITOR_INTERVAL_SECONDS, 1}
       max_batch_size: ${MP_AUTO_BUFFER_MAX_BATCH_SIZE, 30}
@@ -90,12 +90,12 @@ di_container:
 
     multi_manual_step:
       _target_: oqtopus_engine_core.steps.MultiManualStep
-      combiner_address: ${COMBINER_ADDRESS, "localhost:52013"}
+      combiner_address: ${COMBINER_ADDRESS, "localhost:51013"}
       grpc_options: *grpc_options
 
     tranqu_step:
       _target_: oqtopus_engine_core.steps.TranquStep
-      tranqu_address: ${TRANQU_ADDRESS, "localhost:52020"}
+      tranqu_address: ${TRANQU_ADDRESS, "localhost:51020"}
       grpc_options: *grpc_options
       default_transpiler_info:
         transpiler_lib: qiskit
@@ -104,7 +104,7 @@ di_container:
 
     estimator_step:
       _target_: oqtopus_engine_core.steps.EstimatorStep
-      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:52012"}
+      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:51012"}
       grpc_options: *grpc_options
       basis_gates:
         - "cx"
@@ -118,7 +118,7 @@ di_container:
 
     ro_error_mitigation_step:
       _target_: oqtopus_engine_core.steps.ReadoutErrorMitigationStep
-      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:52011"}
+      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:51011"}
       grpc_options: *grpc_options
 
     mp_auto_combining_step:
@@ -126,13 +126,13 @@ di_container:
 
     device_gateway_step:
       _target_: oqtopus_engine_core.steps.DeviceGatewayStep
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
       grpc_options: *grpc_options
 
     sse_step:
       _target_: oqtopus_engine_core.steps.sse_step.SseStep
       runner_settings:
-        sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:52014"}
+        sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:51014"}
         grpc_options: *grpc_options
         host_work_path: ${SSE_HOST_WORK_PATH, "/sse_work"}
         delete_host_temp_dirs: ${SSE_DELETE_HOST_TEMP_DIRS, true}

--- a/core/config/sse_engine_config.yaml
+++ b/core/config/sse_engine_config.yaml
@@ -27,12 +27,12 @@ di_container:
 
     job_fetcher:
       _target_: oqtopus_engine_core.fetchers.SseEngineGateway
-      sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:52014"}
+      sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:51014"}
       grpc_options: *grpc_options
 
     device_fetcher:
       _target_: oqtopus_engine_core.fetchers.DeviceGatewayFetcher
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
       grpc_options: *grpc_options
       initial_interval_seconds: ${DEVICE_FETCHER_INITIAL_INTERVAL_SECONDS, 10}
       initial_backoff_max_seconds: ${DEVICE_FETCHER_INITIAL_BACKOFF_MAX_SECONDS, 60}
@@ -60,11 +60,11 @@ di_container:
 
     multi_manual_step:
       _target_: oqtopus_engine_core.steps.MultiManualStep
-      combiner_address: ${COMBINER_ADDRESS, "localhost:52013"}
+      combiner_address: ${COMBINER_ADDRESS, "localhost:51013"}
 
     tranqu_step:
       _target_: oqtopus_engine_core.steps.TranquStep
-      tranqu_address: ${TRANQU_ADDRESS, "localhost:52020"}
+      tranqu_address: ${TRANQU_ADDRESS, "localhost:51020"}
       grpc_options: *grpc_options
       default_transpiler_info:
         transpiler_lib: qiskit
@@ -73,7 +73,7 @@ di_container:
 
     estimator_step:
       _target_: oqtopus_engine_core.steps.EstimatorStep
-      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:52012"}
+      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:51012"}
       grpc_options: *grpc_options
       basis_gates:
         - "cx"
@@ -87,12 +87,12 @@ di_container:
 
     ro_error_mitigation_step:
       _target_: oqtopus_engine_core.steps.ReadoutErrorMitigationStep
-      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:52011"}
+      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:51011"}
       grpc_options: *grpc_options
 
     device_gateway_step:
       _target_: oqtopus_engine_core.steps.DeviceGatewayStep
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
       grpc_options: *grpc_options
 
     # exception handler configurations

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -16,10 +16,10 @@ pipeline_executor:
     - estimator_step
     - ro_error_mitigation_step
     - mp_auto_combining_step
-    - buffer
+    - ${JOB_BUFFER, buffer}
     - sse_step
     - device_gateway_step
-  job_buffer: buffer
+  job_buffer: ${JOB_BUFFER, buffer}
   exception_handler: pipeline_exception_handler
 
 # Dependency Injection Container Configuration
@@ -40,7 +40,7 @@ di_container:
 
     device_fetcher:
       _target_: oqtopus_engine_core.fetchers.DeviceGatewayFetcher
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
       initial_interval_seconds: ${DEVICE_FETCHER_INITIAL_INTERVAL_SECONDS, 10}
       initial_backoff_max_seconds: ${DEVICE_FETCHER_INITIAL_BACKOFF_MAX_SECONDS, 60}
       loop_interval_seconds: ${DEVICE_FETCHER_LOOP_INTERVAL_SECONDS, 60}
@@ -74,9 +74,9 @@ di_container:
     buffer:
       _target_: oqtopus_engine_core.buffers.QueueBuffer
 
-    _buffer:
+    buffer_mp_auto_combining:
       _target_: oqtopus_engine_core.mp.auto_combining.MpAutoCombiningBuffer
-      combiner_address: ${COMBINER_ADDRESS, "localhost:52013"}
+      combiner_address: ${COMBINER_ADDRESS, "localhost:51013"}
       monitor_interval_seconds: ${MP_AUTO_BUFFER_MONITOR_INTERVAL_SECONDS, 1}
       max_batch_size: ${MP_AUTO_BUFFER_MAX_BATCH_SIZE, 30}
       max_qsize_to_proceed: ${MP_AUTO_BUFFER_MAX_QSIZE_TO_PROCEED, 5}
@@ -90,11 +90,11 @@ di_container:
 
     multi_manual_step:
       _target_: oqtopus_engine_core.steps.MultiManualStep
-      combiner_address: ${COMBINER_ADDRESS, "localhost:52013"}
+      combiner_address: ${COMBINER_ADDRESS, "localhost:51013"}
 
     tranqu_step:
       _target_: oqtopus_engine_core.steps.TranquStep
-      tranqu_address: ${TRANQU_ADDRESS, "localhost:52020"}
+      tranqu_address: ${TRANQU_ADDRESS, "localhost:51020"}
       default_transpiler_info:
         transpiler_lib: qiskit
         transpiler_options:
@@ -102,7 +102,7 @@ di_container:
 
     estimator_step:
       _target_: oqtopus_engine_core.steps.EstimatorStep
-      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:52012"}
+      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:51012"}
       basis_gates:
         - "cx"
         - "id"
@@ -115,19 +115,19 @@ di_container:
 
     ro_error_mitigation_step:
       _target_: oqtopus_engine_core.steps.ReadoutErrorMitigationStep
-      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:52011"}
+      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:51011"}
 
     mp_auto_combining_step:
       _target_: oqtopus_engine_core.mp.auto_combining.MpAutoCombiningStep
 
     device_gateway_step:
       _target_: oqtopus_engine_core.steps.DeviceGatewayStep
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
 
     sse_step:
       _target_: oqtopus_engine_core.steps.sse_step.SseStep
       runner_settings:
-        sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:52014"}
+        sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:51014"}
         host_work_path: ${SSE_HOST_WORK_PATH, "/sse_work"}
         delete_host_temp_dirs: ${SSE_DELETE_HOST_TEMP_DIRS, true}
         container_work_path: ${SSE_CONTAINER_PATH, "/sse"}
@@ -180,11 +180,11 @@ di_container:
 
     job_fetcher:
       _target_: oqtopus_engine_core.fetchers.SseEngineGateway
-      sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:52014"}
+      sse_engine_address: ${SSE_ENGINE_ADDRESS, "localhost:51014"}
 
     device_fetcher:
       _target_: oqtopus_engine_core.fetchers.DeviceGatewayFetcher
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
       initial_interval_seconds: ${DEVICE_FETCHER_INITIAL_INTERVAL_SECONDS, 10}
       initial_backoff_max_seconds: ${DEVICE_FETCHER_INITIAL_BACKOFF_MAX_SECONDS, 60}
       loop_interval_seconds: ${DEVICE_FETCHER_LOOP_INTERVAL_SECONDS, 60}
@@ -211,11 +211,11 @@ di_container:
 
     multi_manual_step:
       _target_: oqtopus_engine_core.steps.MultiManualStep
-      combiner_address: ${COMBINER_ADDRESS, "localhost:52013"}
+      combiner_address: ${COMBINER_ADDRESS, "localhost:51013"}
 
     tranqu_step:
       _target_: oqtopus_engine_core.steps.TranquStep
-      tranqu_address: ${TRANQU_ADDRESS, "localhost:52020"}
+      tranqu_address: ${TRANQU_ADDRESS, "localhost:51020"}
       default_transpiler_info:
         transpiler_lib: qiskit
         transpiler_options:
@@ -223,7 +223,7 @@ di_container:
 
     estimator_step:
       _target_: oqtopus_engine_core.steps.EstimatorStep
-      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:52012"}
+      estimator_address: ${ESTIMATOR_ADDRESS, "localhost:51012"}
       basis_gates:
         - "cx"
         - "id"
@@ -236,16 +236,16 @@ di_container:
 
     ro_error_mitigation_step:
       _target_: oqtopus_engine_core.steps.ReadoutErrorMitigationStep
-      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:52011"}
+      mitigator_address: ${MITIGATOR_ADDRESS, "localhost:51011"}
 
     device_gateway_step:
       _target_: oqtopus_engine_core.steps.DeviceGatewayStep
-      gateway_address: ${GATEWAY_ADDRESS, "localhost:52021"}
+      gateway_address: ${GATEWAY_ADDRESS, "localhost:51021"}
 
     sse_step:
       _target_: oqtopus_engine_core.steps.sse_step.SseStep
       runner_settings:
-        sse_engine_port: ${SSE_GATEWAY_ROUTER_LISTEN_PORT, 52014}
+        sse_engine_port: ${SSE_GATEWAY_ROUTER_LISTEN_PORT, 51014}
 
     # exception handler configurations
     pipeline_exception_handler:


### PR DESCRIPTION
This pull request updates configuration files and documentation to change the default service port numbers from the 520xx range to the 510xx range for several components in the system. It also introduces more flexible buffer configuration by allowing the buffer type to be set via environment variables. These changes help standardize service ports and improve deployment flexibility.

The most important changes are:

**Port Number Updates for Services**

* Changed default port numbers for core services (such as `gateway_address`, `combiner_address`, `tranqu_address`, `estimator_address`, `mitigator_address`, and `sse_engine_address`) from the 520xx range to the 510xx range in both `core/config/config.yaml`, `core/config/sse_engine_config.yaml`, and `docs/usage/config.md`. This affects multiple services including device gateway, combiner, Tranqu, estimator, mitigator, and SSE engine. [[1]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L41-R41) [[2]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L76-R78) [[3]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L93-R98) [[4]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L107-R107) [[5]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L121-R135) [[6]](diffhunk://#diff-84a11b641a13078bdc7b52f522041ee8be7e90f2e549361296412f470ed5f420L30-R35) [[7]](diffhunk://#diff-84a11b641a13078bdc7b52f522041ee8be7e90f2e549361296412f470ed5f420L63-R67) [[8]](diffhunk://#diff-84a11b641a13078bdc7b52f522041ee8be7e90f2e549361296412f470ed5f420L76-R76) [[9]](diffhunk://#diff-84a11b641a13078bdc7b52f522041ee8be7e90f2e549361296412f470ed5f420L90-R95) [[10]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL43-R43) [[11]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL77-R79) [[12]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL93-R105) [[13]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL118-R130) [[14]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL183-R187) [[15]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL214-R226) [[16]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL239-R248)

**Buffer Configuration Improvements**

* Updated buffer configuration in `pipeline_executor` and DI container sections to allow the buffer type to be set via the `${JOB_BUFFER, buffer}` environment variable, increasing flexibility for deployments. [[1]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L13-R16) [[2]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL19-R22)

* Renamed the buffer instance for multi-processing auto-combining from `_buffer` to `buffer_mp_auto_combining` for clarity and consistency. [[1]](diffhunk://#diff-fd0bb7480783d91daf38eca01c7542f46c99d6f2a89a0d8afa5bb265ce00b970L76-R78) [[2]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL77-R79)

**Documentation Updates**

* Updated `docs/usage/config.md` to reflect all the above changes, ensuring that documentation matches the new configuration defaults and environment variable usage. [[1]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL19-R22) [[2]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL43-R43) [[3]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL77-R79) [[4]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL93-R105) [[5]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL118-R130) [[6]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL183-R187) [[7]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL214-R226) [[8]](diffhunk://#diff-1a2a7f6d90890bb1ebf1b5e83d56b7e688674a967dd46aef39e160018e196e7aL239-R248)

These changes are primarily about configuration and do not affect application logic, but they are important for deployment consistency and flexibility.