### PR TITLE
ci: add per-microservice CI workflows with path-based change detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+# Cancel outdated workflows for the same PR or branch
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      mitigator: ${{ steps.filter.outputs.mitigator }}
+      estimator: ${{ steps.filter.outputs.estimator }}
+      combiner: ${{ steps.filter.outputs.combiner }}
+      sse_runtime: ${{ steps.filter.outputs.sse_runtime }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            core:
+              - "core/**"
+            mitigator:
+              - "mitigator/**"
+            estimator:
+              - "estimator/**"
+            combiner:
+              - "combiner/**"
+            sse_runtime:
+              - "sse_runtime/**"
+
+  core:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    uses: ./.github/workflows/service-ci.yml
+    with:
+      service: core
+
+  mitigator:
+    needs: changes
+    if: needs.changes.outputs.mitigator == 'true'
+    uses: ./.github/workflows/service-ci.yml
+    with:
+      service: mitigator
+
+  estimator:
+    needs: changes
+    if: needs.changes.outputs.estimator == 'true'
+    uses: ./.github/workflows/service-ci.yml
+    with:
+      service: estimator
+
+  combiner:
+    needs: changes
+    if: needs.changes.outputs.combiner == 'true'
+    uses: ./.github/workflows/service-ci.yml
+    with:
+      service: combiner
+
+  sse_runtime:
+    needs: changes
+    if: needs.changes.outputs.sse_runtime == 'true'
+    uses: ./.github/workflows/service-ci.yml
+    with:
+      service: sse_runtime

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -1,0 +1,69 @@
+name: Service CI
+
+# Reusable workflow shared by every microservice (core, mitigator, estimator,
+# combiner, sse_runtime). Called from ci.yaml, once per changed service.
+on:
+  workflow_call:
+    inputs:
+      service:
+        description: "Microservice directory to build (core, mitigator, estimator, combiner, sse_runtime)"
+        required: true
+        type: string
+
+defaults:
+  run:
+    working-directory: ${{ inputs.service }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          # Scope the cache key to this service's own uv.lock only.
+          cache-dependency-glob: "${{ inputs.service }}/uv.lock"
+          cache-python: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Show uv and python info
+        run: |
+          uv --version
+          uv run python --version
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-groups
+
+      - name: Lint
+        run: make lint
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          # Scope the cache key to this service's own uv.lock only.
+          cache-dependency-glob: "${{ inputs.service }}/uv.lock"
+          cache-python: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-groups
+
+      - name: Test with coverage
+        run: make test


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) setup using GitHub Actions to streamline how CI tasks are run for each microservice in the repository. The changes add two new workflow files: one for detecting which services have changed and triggering jobs accordingly, and another as a reusable workflow for running linting and tests on each affected service.

**CI Workflow Orchestration:**

* Added `.github/workflows/ci.yaml` to detect changes in individual microservice directories (`core`, `mitigator`, `estimator`, `combiner`, `sse_runtime`) and trigger CI jobs only for those that have changed, improving efficiency and reducing unnecessary runs. This file also ensures outdated workflows are cancelled for the same PR or branch.

**Reusable Service CI Workflow:**

* Added `.github/workflows/service-ci.yml` as a reusable workflow that runs linting and testing for a specified microservice. This workflow is called by `ci.yaml` for each changed service and is parameterized to work with any of the microservices.
* The reusable workflow sets up Python environments using `uv`, installs dependencies with caching per service, and runs `make lint` and `make test` commands for quality and test coverage.