### PR TITLE
fix: set working-directory per step instead of workflow-level defaults in service-ci.yml

### DIFF
--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -10,10 +10,6 @@ on:
         required: true
         type: string
 
-defaults:
-  run:
-    working-directory: ${{ inputs.service }}
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -31,17 +27,21 @@ jobs:
           cache-python: true
 
       - name: Set up Python
+        working-directory: ${{ inputs.service }}
         run: uv python install
 
       - name: Show uv and python info
+        working-directory: ${{ inputs.service }}
         run: |
           uv --version
           uv run python --version
 
       - name: Install dependencies
+        working-directory: ${{ inputs.service }}
         run: uv sync --frozen --all-groups
 
       - name: Lint
+        working-directory: ${{ inputs.service }}
         run: make lint
 
   test:
@@ -60,10 +60,13 @@ jobs:
           cache-python: true
 
       - name: Set up Python
+        working-directory: ${{ inputs.service }}
         run: uv python install
 
       - name: Install dependencies
+        working-directory: ${{ inputs.service }}
         run: uv sync --frozen --all-groups
 
       - name: Test with coverage
+        working-directory: ${{ inputs.service }}
         run: make test


### PR DESCRIPTION
This pull request updates the `.github/workflows/service-ci.yml` workflow to improve how the working directory is set for job steps. Instead of using a global `defaults.run.working-directory`, the `working-directory` is now specified individually for each relevant step. This change provides more granular control and clarity over where each command is executed.

Workflow improvements:

* Removed the global `defaults.run.working-directory` configuration and replaced it by specifying `working-directory: ${{ inputs.service }}` directly in each step that requires it, ensuring commands run in the correct service directory.
* Updated all relevant steps in both the `lint` and `test` jobs to include the explicit `working-directory` field, including Python setup, dependency installation, linting, and testing steps. [[1]](diffhunk://#diff-92bf6de50ee93ed62157d32311c8ab5aececa58b8c0466e0a27886c63b94a7caR30-R44) [[2]](diffhunk://#diff-92bf6de50ee93ed62157d32311c8ab5aececa58b8c0466e0a27886c63b94a7caR63-R71)