### PR TITLE
Minimize the job data passed from sse_step to sse_runtme via environment variables 

### DIFF
--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -160,13 +160,13 @@ di_container:
         userprogram_name: ${SSE_USER_PROGRAM_NAME, "userprogram.py"}
         result_file_name: ${SSE_RESULT_NAME, "result.json"}
         log_file_name: ${SSE_LOG_NAME, "sse_runtime.log"}
-        container_image: ${SSE_CONTAINER_IMAGE, "sse-v2/python3.13:latest"}
+        container_image: ${SSE_CONTAINER_IMAGE, "sse-runtime:latest"}
         container_disk_quota: ${SSE_CONTAINER_DISK_QUOTA, 67108864}
         container_memory: ${SSE_CONTAINER_MEMORY, 268435456}
         container_cpu_set: ${SSE_CONTAINER_CPU_SET, "0"}
         container_network: ${SSE_CONTAINER_NETWORK, "context_app_net"}
         container_extra_hosts:
-          - sse_engine:${SSE_ENGINE_IP, localhost}
+          sse_engine: ${SSE_ENGINE_IP, "host-gateway"}
         timeout: ${SSE_TIMEOUT, 600}
 
     # exception handler configurations

--- a/core/src/oqtopus_engine_core/steps/sse_step.py
+++ b/core/src/oqtopus_engine_core/steps/sse_step.py
@@ -19,25 +19,6 @@ from oqtopus_engine_core.framework import (
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_RUNNER_SETTINGS: dict[str, Any] = {
-    "sse_engine_address": "sse_engine:51014",
-    "grpc_options": [],
-    "host_work_path": "/sse_work",
-    "delete_host_temp_dirs": True,
-    "container_work_path": "/sse",
-    "userprogram_name": "userprogram.py",
-    "base_job_file_name": "base_job.json",
-    "result_file_name": "result.json",
-    "log_file_name": "sse_runtime.log",
-    "container_image": "sse-runtime:latest",
-    "container_disk_quota": 64 * 1024 * 1024,
-    "container_memory": 256 * 1024 * 1024,
-    "container_cpu_set": "0",
-    "container_network": None,
-    "container_extra_hosts": {"sse_engine": "host-gateway"},
-    "timeout": 600,
-}
-
 
 class SseStep(Step):
     """Step to run SSE."""
@@ -47,7 +28,7 @@ class SseStep(Step):
         runner_settings: dict[str, Any],
     ) -> None:
 
-        self._settings = {**_DEFAULT_RUNNER_SETTINGS, **runner_settings}
+        self._settings = runner_settings
         logger.info(
             "SseStep was initialized",
             extra={"runner_settings": runner_settings},
@@ -451,26 +432,6 @@ class SseRunner:
                 extra={"job_id": self._job_id},
             )
 
-        # ====== copy base job file into container ========
-        base_job_file_name = self._config["base_job_file_name"]
-        try:
-            await self._copy_file_into_container(
-                user="appuser",
-                file_name=base_job_file_name,
-                file_content=self._job.model_dump_json().encode("utf-8"),
-            )
-        except Exception as e:
-            self._stop_and_remove()
-            msg = f"failed to copy base job file into container. Job({self._job_id})"
-            raise RuntimeError(msg) from e
-        else:
-            logger.debug(
-                "base job file copied into SSE container successfully",
-                extra={"job_id": self._job_id,
-                       "base_job_file_name": base_job_file_name
-                       },
-            )
-
         # ======== copy user program into container ========
         try:
             logger.debug(
@@ -482,10 +443,10 @@ class SseRunner:
             )
             with userprogram_host_path.open("rb") as f:
                 content = f.read()
-            await self._copy_file_into_container(
+            await self._copy_user_program_into_container(
                 user="appuser",
-                file_name=self._config["userprogram_name"],
-                file_content=content,
+                user_program_name=self._config["userprogram_name"],
+                user_program_content=content,
             )
         except Exception as e:
             self._stop_and_remove()
@@ -600,8 +561,7 @@ class SseRunner:
 
         # Set environment variables in container
         env_vars = [
-            f"BASE_JOB_FILE_NAME={self._config['base_job_file_name']}",
-            f"IN_PATH={self._container_work_path['in']}",
+            f"JOB_ID={self._job_id}",
             f"OUT_PATH={self._container_work_path['out']}",
             f"SSE_ENGINE_ADDRESS={self._config['sse_engine_address']}",
             f"GRPC_MAX_RECEIVE_MESSAGE_LENGTH={grpc_max_receive}",
@@ -677,24 +637,21 @@ class SseRunner:
             msg = "timeout when executing command in container"
             raise TimeoutError(msg) from e
 
-    async def _copy_file_into_container(
-        self, user: str, file_name: str, file_content: bytes
+    async def _copy_user_program_into_container(
+        self, user: str, user_program_name: str, user_program_content: bytes
     ) -> None:
         logger.debug(
-            "copying a file into container",
-            extra={"job_id": self._job_id,
-                   "file_name": file_name,
-                   "file_size_in_bytes": len(file_content),
-                   },
+            "copying user program into container",
+            extra={"job_id": self._job_id},
         )
 
         # Create tar archive in memory
         data = io.BytesIO()
         with tarfile.open(fileobj=data, mode="w") as tar:
-            info = tarfile.TarInfo(name=file_name)
+            info = tarfile.TarInfo(name=user_program_name)
             info.mode = 0o755
-            info.size = len(file_content)
-            tar.addfile(tarinfo=info, fileobj=io.BytesIO(file_content))
+            info.size = len(user_program_content)
+            tar.addfile(tarinfo=info, fileobj=io.BytesIO(user_program_content))
         data.seek(0)
 
         # Copy the tar archive into container tmpfs
@@ -710,13 +667,11 @@ class SseRunner:
         await self._exec_in_container(
             user=user,
             privileged=False,
-            cmd=f"mv {tmp_dir / file_name} {self._container_work_path['in']}",
+            cmd=f"mv {tmp_dir / user_program_name} {self._container_work_path['in']}",
         )
         logger.debug(
-            "file copied to tmpfs successfully",
-            extra={"job_id": self._job_id,
-                   "file_name": file_name,
-                   },
+            "user program copied to tmpfs successfully",
+            extra={"job_id": self._job_id},
         )
 
     def _get_result_from_container(

--- a/core/src/oqtopus_engine_core/steps/sse_step.py
+++ b/core/src/oqtopus_engine_core/steps/sse_step.py
@@ -19,6 +19,25 @@ from oqtopus_engine_core.framework import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_RUNNER_SETTINGS: dict[str, Any] = {
+    "sse_engine_address": "sse_engine:51014",
+    "grpc_options": [],
+    "host_work_path": "/sse_work",
+    "delete_host_temp_dirs": True,
+    "container_work_path": "/sse",
+    "userprogram_name": "userprogram.py",
+    "base_job_file_name": "base_job.json",
+    "result_file_name": "result.json",
+    "log_file_name": "sse_runtime.log",
+    "container_image": "sse-runtime:latest",
+    "container_disk_quota": 64 * 1024 * 1024,
+    "container_memory": 256 * 1024 * 1024,
+    "container_cpu_set": "0",
+    "container_network": None,
+    "container_extra_hosts": {"sse_engine": "host-gateway"},
+    "timeout": 600,
+}
+
 
 class SseStep(Step):
     """Step to run SSE."""
@@ -28,7 +47,7 @@ class SseStep(Step):
         runner_settings: dict[str, Any],
     ) -> None:
 
-        self._settings = runner_settings
+        self._settings = {**_DEFAULT_RUNNER_SETTINGS, **runner_settings}
         logger.info(
             "SseStep was initialized",
             extra={"runner_settings": runner_settings},
@@ -432,6 +451,26 @@ class SseRunner:
                 extra={"job_id": self._job_id},
             )
 
+        # ====== copy base job file into container ========
+        base_job_file_name = self._config["base_job_file_name"]
+        try:
+            await self._copy_file_into_container(
+                user="appuser",
+                file_name=base_job_file_name,
+                file_content=self._job.model_dump_json().encode("utf-8"),
+            )
+        except Exception as e:
+            self._stop_and_remove()
+            msg = f"failed to copy base job file into container. Job({self._job_id})"
+            raise RuntimeError(msg) from e
+        else:
+            logger.debug(
+                "base job file copied into SSE container successfully",
+                extra={"job_id": self._job_id,
+                       "base_job_file_name": base_job_file_name
+                       },
+            )
+
         # ======== copy user program into container ========
         try:
             logger.debug(
@@ -443,10 +482,10 @@ class SseRunner:
             )
             with userprogram_host_path.open("rb") as f:
                 content = f.read()
-            await self._copy_user_program_into_container(
+            await self._copy_file_into_container(
                 user="appuser",
-                user_program_name=self._config["userprogram_name"],
-                user_program_content=content,
+                file_name=self._config["userprogram_name"],
+                file_content=content,
             )
         except Exception as e:
             self._stop_and_remove()
@@ -561,7 +600,7 @@ class SseRunner:
 
         # Set environment variables in container
         env_vars = [
-            f"JOB_JSON={self._job.model_dump_json()}",
+            f"BASE_JOB_FILE_NAME={self._config['base_job_file_name']}",
             f"IN_PATH={self._container_work_path['in']}",
             f"OUT_PATH={self._container_work_path['out']}",
             f"SSE_ENGINE_ADDRESS={self._config['sse_engine_address']}",
@@ -638,21 +677,24 @@ class SseRunner:
             msg = "timeout when executing command in container"
             raise TimeoutError(msg) from e
 
-    async def _copy_user_program_into_container(
-        self, user: str, user_program_name: str, user_program_content: bytes
+    async def _copy_file_into_container(
+        self, user: str, file_name: str, file_content: bytes
     ) -> None:
         logger.debug(
-            "copying user program into container",
-            extra={"job_id": self._job_id},
+            "copying a file into container",
+            extra={"job_id": self._job_id,
+                   "file_name": file_name,
+                   "file_size_in_bytes": len(file_content),
+                   },
         )
 
         # Create tar archive in memory
         data = io.BytesIO()
         with tarfile.open(fileobj=data, mode="w") as tar:
-            info = tarfile.TarInfo(name=user_program_name)
+            info = tarfile.TarInfo(name=file_name)
             info.mode = 0o755
-            info.size = len(user_program_content)
-            tar.addfile(tarinfo=info, fileobj=io.BytesIO(user_program_content))
+            info.size = len(file_content)
+            tar.addfile(tarinfo=info, fileobj=io.BytesIO(file_content))
         data.seek(0)
 
         # Copy the tar archive into container tmpfs
@@ -668,11 +710,13 @@ class SseRunner:
         await self._exec_in_container(
             user=user,
             privileged=False,
-            cmd=f"mv {tmp_dir / user_program_name} {self._container_work_path['in']}",
+            cmd=f"mv {tmp_dir / file_name} {self._container_work_path['in']}",
         )
         logger.debug(
-            "user program copied to tmpfs successfully",
-            extra={"job_id": self._job_id},
+            "file copied to tmpfs successfully",
+            extra={"job_id": self._job_id,
+                   "file_name": file_name,
+                   },
         )
 
     def _get_result_from_container(

--- a/core/tests/oqtopus_engine_core/steps/test_sse_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_sse_step.py
@@ -68,7 +68,6 @@ def runner_settings(tmp_path: Path) -> dict:
         "host_work_path": str(tmp_path / "work"),
         "container_work_path": "/sse",
         "userprogram_name": "main.py",
-        "base_job_file_name": "base_job.json",
         "result_file_name": "result.json",
         "log_file_name": "log.txt",
         "delete_host_temp_dirs": True,
@@ -791,7 +790,7 @@ class TestExecInContainer:
 
 
 # ---------------------------------------------------------------------------
-# SseRunner._copy_file_into_container
+# SseRunner._copy_user_program_into_container
 # ---------------------------------------------------------------------------
 
 class TestCopyUserProgramIntoContainer:
@@ -802,10 +801,10 @@ class TestCopyUserProgramIntoContainer:
         runner._container.put_archive.return_value = True
         runner._exec_in_container = AsyncMock()
 
-        await runner._copy_file_into_container(
+        await runner._copy_user_program_into_container(
             user="appuser",
-            file_name="main.py",
-            file_content=b"print('hi')",
+            user_program_name="main.py",
+            user_program_content=b"print('hi')",
         )
 
         runner._container.put_archive.assert_called_once()
@@ -818,10 +817,10 @@ class TestCopyUserProgramIntoContainer:
         runner._container.put_archive.return_value = False
 
         with pytest.raises(RuntimeError, match="failed to put archive"):
-            await runner._copy_file_into_container(
+            await runner._copy_user_program_into_container(
                 user="appuser",
-                file_name="main.py",
-                file_content=b"data",
+                user_program_name="main.py",
+                user_program_content=b"data",
             )
 
 
@@ -979,14 +978,14 @@ class TestPreprocessContainer:
         mock_container.put_archive.return_value = True
         runner._start_container = MagicMock(return_value=mock_container)
         runner._exec_in_container = AsyncMock()
-        runner._copy_file_into_container = AsyncMock()
+        runner._copy_user_program_into_container = AsyncMock()
 
         await runner._preprocess_container()
 
         runner._start_container.assert_called_once()
         assert runner._container is mock_container
         runner._exec_in_container.assert_awaited_once()
-        assert runner._copy_file_into_container.await_count == 2
+        runner._copy_user_program_into_container.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_start_container_failure(self, make_runner: _MakeRunner) -> None:
@@ -1032,8 +1031,8 @@ class TestPreprocessContainer:
         mock_container = MagicMock()
         runner._start_container = MagicMock(return_value=mock_container)
         runner._exec_in_container = AsyncMock()  # init succeeds
-        runner._copy_file_into_container = AsyncMock(
-            side_effect=[None, RuntimeError("copy fail")]
+        runner._copy_user_program_into_container = AsyncMock(
+            side_effect=RuntimeError("copy fail")
         )
         runner._stop_and_remove = MagicMock()
 

--- a/core/tests/oqtopus_engine_core/steps/test_sse_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_sse_step.py
@@ -68,17 +68,23 @@ def runner_settings(tmp_path: Path) -> dict:
         "host_work_path": str(tmp_path / "work"),
         "container_work_path": "/sse",
         "userprogram_name": "main.py",
+        "base_job_file_name": "base_job.json",
         "result_file_name": "result.json",
         "log_file_name": "log.txt",
         "delete_host_temp_dirs": True,
         "container_image": "sse-runtime:latest",
         "sse_engine_address": "localhost:50051",
+        "grpc_options": [
+            ("grpc.max_receive_message_length", 10_000_000),
+            ("grpc.max_send_message_length", 10_000_000)
+        ],
         "timeout": 600,
         "max_file_size": 10_000_000,
         "container_disk_quota": 67_108_864,
         "container_memory": 268_435_456,
         "container_cpu_set": "0",
         "container_network": "sse_net",
+        "container_extra_hosts": ["sse_engine:host-gateway"],
     }
 
 
@@ -111,7 +117,7 @@ def sample_job() -> Job:
 class TestSseStepInit:
     def test_init_stores_settings(self, runner_settings: dict) -> None:
         step = SseStep(runner_settings=runner_settings)
-        assert step._settings is runner_settings
+        assert step._settings == runner_settings
 
 
 class TestSseStepPreProcess:
@@ -785,7 +791,7 @@ class TestExecInContainer:
 
 
 # ---------------------------------------------------------------------------
-# SseRunner._copy_user_program_into_container
+# SseRunner._copy_file_into_container
 # ---------------------------------------------------------------------------
 
 class TestCopyUserProgramIntoContainer:
@@ -796,10 +802,10 @@ class TestCopyUserProgramIntoContainer:
         runner._container.put_archive.return_value = True
         runner._exec_in_container = AsyncMock()
 
-        await runner._copy_user_program_into_container(
+        await runner._copy_file_into_container(
             user="appuser",
-            user_program_name="main.py",
-            user_program_content=b"print('hi')",
+            file_name="main.py",
+            file_content=b"print('hi')",
         )
 
         runner._container.put_archive.assert_called_once()
@@ -812,10 +818,10 @@ class TestCopyUserProgramIntoContainer:
         runner._container.put_archive.return_value = False
 
         with pytest.raises(RuntimeError, match="failed to put archive"):
-            await runner._copy_user_program_into_container(
+            await runner._copy_file_into_container(
                 user="appuser",
-                user_program_name="main.py",
-                user_program_content=b"data",
+                file_name="main.py",
+                file_content=b"data",
             )
 
 
@@ -973,14 +979,14 @@ class TestPreprocessContainer:
         mock_container.put_archive.return_value = True
         runner._start_container = MagicMock(return_value=mock_container)
         runner._exec_in_container = AsyncMock()
-        runner._copy_user_program_into_container = AsyncMock()
+        runner._copy_file_into_container = AsyncMock()
 
         await runner._preprocess_container()
 
         runner._start_container.assert_called_once()
         assert runner._container is mock_container
         runner._exec_in_container.assert_awaited_once()
-        runner._copy_user_program_into_container.assert_awaited_once()
+        assert runner._copy_file_into_container.await_count == 2
 
     @pytest.mark.asyncio
     async def test_start_container_failure(self, make_runner: _MakeRunner) -> None:
@@ -1025,9 +1031,9 @@ class TestPreprocessContainer:
 
         mock_container = MagicMock()
         runner._start_container = MagicMock(return_value=mock_container)
-        runner._exec_in_container = AsyncMock()
-        runner._copy_user_program_into_container = AsyncMock(
-            side_effect=RuntimeError("copy fail")
+        runner._exec_in_container = AsyncMock()  # init succeeds
+        runner._copy_file_into_container = AsyncMock(
+            side_effect=[None, RuntimeError("copy fail")]
         )
         runner._stop_and_remove = MagicMock()
 

--- a/core/tests/oqtopus_engine_core/steps/test_sse_step.py
+++ b/core/tests/oqtopus_engine_core/steps/test_sse_step.py
@@ -83,7 +83,7 @@ def runner_settings(tmp_path: Path) -> dict:
         "container_memory": 268_435_456,
         "container_cpu_set": "0",
         "container_network": "sse_net",
-        "container_extra_hosts": ["sse_engine:host-gateway"],
+        "container_extra_hosts": {"sse_engine": "host-gateway"},
     }
 
 

--- a/sse_runtime/compose.yaml
+++ b/sse_runtime/compose.yaml
@@ -1,6 +1,6 @@
 services:
   sse:
-    image: ${SSE_CONTAINER_IMAGE:-sse-v2/python3.13}
+    image: ${SSE_CONTAINER_IMAGE:-sse-runtime:latest}
     build:
       context: .
     working_dir: '/sse/'

--- a/sse_runtime/src/sse_runtime/sse_driver.py
+++ b/sse_runtime/src/sse_runtime/sse_driver.py
@@ -34,7 +34,6 @@ def submit_job(
             returns the OQTOPUS Client Job.
 
     Raises:
-        OSError: If the job data is not set.
         SseRuntimeError: If the job execution fails.
 
     """
@@ -53,11 +52,19 @@ def submit_job(
         )
     )
 
-    # get job data from environment variable
-    job_json = os.environ.get("JOB_JSON")
-    if not job_json:
-        msg = "Could not get job data"
-        raise OSError(msg)
+    # get job data from a file
+    base_job_path = Path(
+        os.environ.get("IN_PATH", "in"),
+        os.environ.get("BASE_JOB_FILE_NAME", "base_job.json"),
+    )
+    try:
+        job_json = Path(base_job_path).read_text(encoding="utf-8")
+        if not job_json:
+            msg = "Could not get base job data: empty content"
+            raise SseRuntimeError(msg)
+    except FileNotFoundError as e:
+        msg = f"Could not get base job data: file not found at {base_job_path}"
+        raise SseRuntimeError(msg) from e
 
     grpc_options = [
         ("grpc.max_receive_message_length", grpc_max_receive),

--- a/sse_runtime/src/sse_runtime/sse_driver.py
+++ b/sse_runtime/src/sse_runtime/sse_driver.py
@@ -52,19 +52,11 @@ def submit_job(
         )
     )
 
-    # get job data from a file
-    base_job_path = Path(
-        os.environ.get("IN_PATH", "in"),
-        os.environ.get("BASE_JOB_FILE_NAME", "base_job.json"),
-    )
-    try:
-        job_json = Path(base_job_path).read_text(encoding="utf-8")
-        if not job_json:
-            msg = "Could not get base job data: empty content"
-            raise SseRuntimeError(msg)
-    except FileNotFoundError as e:
-        msg = f"Could not get base job data: file not found at {base_job_path}"
-        raise SseRuntimeError(msg) from e
+    # get the parent SSE job id from an environment variable
+    job_id = os.environ.get("JOB_ID")
+    if not job_id:
+        msg = "Could not get JOB_ID from environment"
+        raise SseRuntimeError(msg)
 
     grpc_options = [
         ("grpc.max_receive_message_length", grpc_max_receive),
@@ -76,7 +68,7 @@ def submit_job(
     ) as channel:
         created = _now_utc()
         stub = sse_pb2_grpc.SseEngineServiceStub(channel)
-        request_dict = _make_request(job_json, input_job, upload_info)
+        request_dict = _make_request(job_id, input_job, upload_info)
         # gRPC request
         request = sse_pb2.SseEngineRequest(job_json=json.dumps(request_dict))
         response = stub.SseEngine(request)
@@ -99,13 +91,13 @@ def submit_job(
 
 
 def _make_request(
-    job_json: str,
+    job_id: str,
     input_job: JobsSubmitJobRequest,
     upload_info: JobsS3SubmitJobInfo,
 ) -> dict[str, Any]:
     request = _convert_to_engine_job_model(input_job, upload_info)
     # set job_id of parent SSE job and status
-    request["job_id"] = _load_json_dict(job_json).get("job_id") or ""
+    request["job_id"] = job_id
     request["status"] = "ready"
     return request
 
@@ -139,17 +131,6 @@ def _convert_to_oqtopus_client_job_model(
         msg = f"Could not parse job data: {e}"
         raise SseRuntimeError(msg) from e
     return job
-
-
-def _load_json_dict(raw_json: str | None) -> dict[str, Any]:
-    if not raw_json:
-        return {}
-
-    loaded = json.loads(raw_json)
-    if not isinstance(loaded, dict):
-        msg = "Expected job data to be a JSON object"
-        raise SseRuntimeError(msg)
-    return loaded
 
 
 def _job_message(job: JobsJob) -> str | None:

--- a/sse_runtime/tests/sse_runtime/test_sse_driver.py
+++ b/sse_runtime/tests/sse_runtime/test_sse_driver.py
@@ -301,53 +301,32 @@ def _build_expected_request(
     return expected_request
 
 
-def _write_base_job_file(
-    tmp_path: Path, payload: str = '{"job_id":"parent-1"}'
-) -> None:
-    (tmp_path / "base_job.json").write_text(payload, encoding="utf-8")
-
-
-# -----------------------------
-# JSON/serialization utilities
-# -----------------------------
-@pytest.mark.parametrize("raw_json", [None, ""])
-def test_load_json_dict_returns_empty_when_raw_json_is_missing_or_empty(
-    raw_json: str | None,
-) -> None:
-    assert sse_driver._load_json_dict(raw_json) == {}
-
-
-def test_load_json_dict_raises_when_json_is_not_object() -> None:
-    with pytest.raises(sse_driver.SseRuntimeError, match="JSON object"):
-        sse_driver._load_json_dict("[]")
-
-
 # -----------------
 # Request builders
 # -----------------
 @pytest.mark.parametrize(
-    ("input_job_factory", "job_json"),
+    ("input_job_factory", "job_id"),
     [
         pytest.param(
             _build_submit_job_request,
-            '{"job_id": "parent-id"}',
+            "parent-id",
             id="overrides-fields",
         ),
         pytest.param(
             _build_submit_job_request_full,
-            '{"job_id": "parent-id"}',
+            "parent-id",
             id="keeps-model-fields",
         ),
     ],
 )
 def test_make_request_merges_submit_job_request_and_upload_info(
     input_job_factory: Any,
-    job_json: str,
+    job_id: str,
 ) -> None:
     input_job = input_job_factory()
     upload_info = _build_upload_info()
 
-    request = sse_driver._make_request(job_json, input_job, upload_info)
+    request = sse_driver._make_request(job_id, input_job, upload_info)
 
     _assert_make_request_payload(
         request,
@@ -361,7 +340,7 @@ def test_make_request_merges_submit_job_request_and_upload_info(
 
 def test_make_request_serializes_operator_items() -> None:
     request = sse_driver._make_request(
-        '{"job_id": "parent-id"}',
+        "parent-id",
         _build_submit_job_request(),
         _build_upload_info_with_operator(),
     )
@@ -395,16 +374,13 @@ def test_log_result_raises_when_out_path_does_not_exist(
         sse_driver._log_result(json.dumps({"status": "failed"}), "result.json")
 
 
-def test_submit_job_raises_when_base_job_json_missing(
+def test_submit_job_raises_when_job_id_missing(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("IN_PATH", str(tmp_path))
+    monkeypatch.delenv("JOB_ID", raising=False)
 
     with pytest.raises(
-        sse_driver.SseRuntimeError,
-        match=f"Could not get base job data: file not found at "
-        f"{tmp_path / 'base_job.json'}",
+        sse_driver.SseRuntimeError, match="Could not get JOB_ID from environment"
     ):
         sse_driver.submit_job(
             _build_submit_job_request(),
@@ -412,15 +388,13 @@ def test_submit_job_raises_when_base_job_json_missing(
         )
 
 
-def test_submit_job_raises_when_base_job_json_empty(
+def test_submit_job_raises_when_job_id_empty(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("IN_PATH", str(tmp_path))
-    _write_base_job_file(tmp_path, payload="")
+    monkeypatch.setenv("JOB_ID", "")
 
     with pytest.raises(
-        sse_driver.SseRuntimeError, match="Could not get base job data: empty content"
+        sse_driver.SseRuntimeError, match="Could not get JOB_ID from environment"
     ):
         sse_driver.submit_job(
             _build_submit_job_request(),
@@ -567,8 +541,7 @@ def test_submit_job_grpc_success_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    _write_base_job_file(tmp_path)
-    monkeypatch.setenv("IN_PATH", str(tmp_path))
+    monkeypatch.setenv("JOB_ID", "parent-1")
     monkeypatch.setenv("SSE_ENGINE_ADDRESS", "test-host:1234")
     monkeypatch.setenv("OUT_PATH", str(tmp_path))
 
@@ -648,8 +621,7 @@ def test_submit_job_raises_when_status_failed(
     job_message: str,
     expected_error: str,
 ) -> None:
-    _write_base_job_file(tmp_path)
-    monkeypatch.setenv("IN_PATH", str(tmp_path))
+    monkeypatch.setenv("JOB_ID", "parent-1")
     monkeypatch.setenv("OUT_PATH", str(tmp_path))
 
     fake_response = SimpleNamespace(

--- a/sse_runtime/tests/sse_runtime/test_sse_driver.py
+++ b/sse_runtime/tests/sse_runtime/test_sse_driver.py
@@ -301,6 +301,12 @@ def _build_expected_request(
     return expected_request
 
 
+def _write_base_job_file(
+    tmp_path: Path, payload: str = '{"job_id":"parent-1"}'
+) -> None:
+    (tmp_path / "base_job.json").write_text(payload, encoding="utf-8")
+
+
 # -----------------------------
 # JSON/serialization utilities
 # -----------------------------
@@ -389,12 +395,33 @@ def test_log_result_raises_when_out_path_does_not_exist(
         sse_driver._log_result(json.dumps({"status": "failed"}), "result.json")
 
 
-def test_submit_job_raises_when_job_json_missing(
+def test_submit_job_raises_when_base_job_json_missing(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("JOB_JSON", raising=False)
+    monkeypatch.setenv("IN_PATH", str(tmp_path))
 
-    with pytest.raises(OSError, match="Could not get job data"):
+    with pytest.raises(
+        sse_driver.SseRuntimeError,
+        match=f"Could not get base job data: file not found at "
+        f"{tmp_path / 'base_job.json'}",
+    ):
+        sse_driver.submit_job(
+            _build_submit_job_request(),
+            _build_upload_info(),
+        )
+
+
+def test_submit_job_raises_when_base_job_json_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("IN_PATH", str(tmp_path))
+    _write_base_job_file(tmp_path, payload="")
+
+    with pytest.raises(
+        sse_driver.SseRuntimeError, match="Could not get base job data: empty content"
+    ):
         sse_driver.submit_job(
             _build_submit_job_request(),
             _build_upload_info(),
@@ -540,7 +567,8 @@ def test_submit_job_grpc_success_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("JOB_JSON", '{"job_id":"parent-1"}')
+    _write_base_job_file(tmp_path)
+    monkeypatch.setenv("IN_PATH", str(tmp_path))
     monkeypatch.setenv("SSE_ENGINE_ADDRESS", "test-host:1234")
     monkeypatch.setenv("OUT_PATH", str(tmp_path))
 
@@ -620,7 +648,8 @@ def test_submit_job_raises_when_status_failed(
     job_message: str,
     expected_error: str,
 ) -> None:
-    monkeypatch.setenv("JOB_JSON", '{"job_id":"parent-1"}')
+    _write_base_job_file(tmp_path)
+    monkeypatch.setenv("IN_PATH", str(tmp_path))
     monkeypatch.setenv("OUT_PATH", str(tmp_path))
 
     fake_response = SimpleNamespace(
@@ -638,7 +667,7 @@ def test_submit_job_raises_when_status_failed(
     monkeypatch.setattr(
         sse_driver.grpc,
         "insecure_channel",
-        lambda _address, options=None: _DummyChannel(object()),
+        lambda _address, options=None: _DummyChannel(object()),  # noqa: ARG005
     )
     monkeypatch.setattr(
         sse_driver.sse_pb2_grpc,


### PR DESCRIPTION
# 📃 Ticket
- #86 

## ✍ Description
Modified SSE to pass only the job ID to sse_runtime via an environment variable instead of the entire job payload. 
The remaining payload data is no longer used.
This change enables SSE to run successfully even when the user program exceeds 128 KB.

